### PR TITLE
添加 GetPluginPackageDetail 接口及 HTTP 端点

### DIFF
--- a/das/Core/ForeignInterfaceHost/include/das/Core/ForeignInterfaceHost/PluginManagerServiceImpl.h
+++ b/das/Core/ForeignInterfaceHost/include/das/Core/ForeignInterfaceHost/PluginManagerServiceImpl.h
@@ -28,6 +28,9 @@ public:
     // IDasPluginManagerService
     DasResult ScanInstalledPlugins(
         Das::ExportInterface::IDasJson** pp_out_plugins) override;
+    DasResult GetPluginPackageDetail(
+        const DasGuid*                   p_package_guid,
+        Das::ExportInterface::IDasJson** pp_out_detail) override;
     DasResult InstallPluginPackage(IDasReadOnlyString* p_package_path) override;
     DasResult InstallPluginPackageData(
         const uint8_t* p_package_data,

--- a/das/Core/ForeignInterfaceHost/include/das/Core/ForeignInterfaceHost/PluginScanner.h
+++ b/das/Core/ForeignInterfaceHost/include/das/Core/ForeignInterfaceHost/PluginScanner.h
@@ -26,6 +26,9 @@ DAS_EXPORT std::filesystem::path FindManifest(
 
 DAS_EXPORT yyjson::value PluginPackageDescToJson(const PluginPackageDesc& desc);
 
+DAS_EXPORT yyjson::value PluginPackageDescDetailToJson(
+    const PluginPackageDesc& desc);
+
 DAS_CORE_FOREIGNINTERFACEHOST_NS_END
 
 #endif // DAS_CORE_FOREIGNINTERFACEHOST_PLUGINSCANNER_H

--- a/das/Core/ForeignInterfaceHost/src/PluginManagerServiceImpl.cpp
+++ b/das/Core/ForeignInterfaceHost/src/PluginManagerServiceImpl.cpp
@@ -252,6 +252,34 @@ DasResult PluginManagerServiceImpl::ScanInstalledPlugins(
     return CreateDasJsonFromYyjson(arr, pp_out_plugins);
 }
 
+DasResult PluginManagerServiceImpl::GetPluginPackageDetail(
+    const DasGuid*                   p_package_guid,
+    Das::ExportInterface::IDasJson** pp_out_detail)
+{
+    DAS_UTILS_CHECK_POINTER(pp_out_detail)
+    DAS_UTILS_CHECK_POINTER(p_package_guid)
+
+    auto                     descs = ScanPlugins(plugin_dir_);
+    const PluginPackageDesc* found = nullptr;
+    for (const auto& desc : descs)
+    {
+        if (desc.guid == *p_package_guid)
+        {
+            found = &desc;
+            break;
+        }
+    }
+    if (!found)
+    {
+        return DAS_E_NOT_FOUND;
+    }
+
+    auto detail_json = PluginPackageDescDetailToJson(*found);
+
+    using Das::Core::Utils::CreateDasJsonFromYyjson;
+    return CreateDasJsonFromYyjson(detail_json, pp_out_detail);
+}
+
 DasResult PluginManagerServiceImpl::InstallPluginPackage(
     IDasReadOnlyString* p_package_path)
 {
@@ -292,9 +320,8 @@ DasResult PluginManagerServiceImpl::InstallPluginPackageData(
         plugin_name);
     if (DAS::IsFailed(meta_result))
     {
-        DAS_CORE_LOG_ERROR(
-            "InstallPluginPackageData: failed to read identity "
-            "from zip manifest");
+        DAS_CORE_LOG_ERROR("InstallPluginPackageData: failed to read identity "
+                           "from zip manifest");
         return meta_result;
     }
 

--- a/das/Core/ForeignInterfaceHost/src/PluginScanner.cpp
+++ b/das/Core/ForeignInterfaceHost/src/PluginScanner.cpp
@@ -364,4 +364,325 @@ yyjson::value PluginPackageDescToJson(const PluginPackageDesc& desc)
     return j;
 }
 
+namespace
+{
+    yyjson::value PluginSettingDescToJson(const PluginSettingDesc& setting)
+    {
+        auto j = Das::Utils::MakeYyjsonObject();
+        auto obj = j.as_object();
+        if (!obj)
+        {
+            return j;
+        }
+        (*obj)[std::string_view("name")] =
+            std::make_pair(std::string_view(setting.name), yyjson::copy_string);
+        (*obj)[std::string_view("type")] =
+            static_cast<std::int64_t>(setting.type);
+        (*obj)[std::string_view("required")] = setting.required;
+
+        if (setting.description.has_value())
+        {
+            (*obj)[std::string_view("description")] = std::make_pair(
+                std::string_view(setting.description.value()),
+                yyjson::copy_string);
+        }
+
+        if (setting.deprecation_message.has_value())
+        {
+            (*obj)[std::string_view("deprecationMessage")] = std::make_pair(
+                std::string_view(setting.deprecation_message.value()),
+                yyjson::copy_string);
+        }
+
+        if (setting.enum_values.has_value())
+        {
+            auto arr = Das::Utils::MakeYyjsonArray();
+            auto arr_ref = arr.as_array();
+            if (arr_ref)
+            {
+                for (const auto& v : setting.enum_values.value())
+                {
+                    arr_ref->emplace_back(std::string(v));
+                }
+            }
+            (*obj)[std::string_view("enumValues")] = std::move(arr);
+        }
+
+        if (setting.enum_descriptions.has_value())
+        {
+            auto arr = Das::Utils::MakeYyjsonArray();
+            auto arr_ref = arr.as_array();
+            if (arr_ref)
+            {
+                for (const auto& v : setting.enum_descriptions.value())
+                {
+                    arr_ref->emplace_back(std::string(v));
+                }
+            }
+            (*obj)[std::string_view("enumDescriptions")] = std::move(arr);
+        }
+
+        std::visit(
+            [&obj](const auto& val)
+            {
+                using T = std::decay_t<decltype(val)>;
+                if constexpr (std::is_same_v<T, std::monostate>)
+                {
+                    (*obj)[std::string_view("defaultValue")] =
+                        yyjson::value(nullptr);
+                }
+                else if constexpr (std::is_same_v<T, bool>)
+                {
+                    (*obj)[std::string_view("defaultValue")] = val;
+                }
+                else if constexpr (std::is_same_v<T, std::int64_t>)
+                {
+                    (*obj)[std::string_view("defaultValue")] = val;
+                }
+                else if constexpr (std::is_same_v<T, float>)
+                {
+                    (*obj)[std::string_view("defaultValue")] =
+                        static_cast<double>(val);
+                }
+                else if constexpr (std::is_same_v<T, std::string>)
+                {
+                    (*obj)[std::string_view("defaultValue")] = std::make_pair(
+                        std::string_view(val),
+                        yyjson::copy_string);
+                }
+            },
+            setting.default_value);
+
+        return j;
+    }
+
+} // anonymous namespace
+
+yyjson::value PluginPackageDescDetailToJson(const PluginPackageDesc& desc)
+{
+    auto j = PluginPackageDescToJson(desc);
+    auto obj = j.as_object();
+    if (!obj)
+    {
+        return j;
+    }
+
+    (*obj)[std::string_view("loadMode")] =
+        static_cast<std::int64_t>(desc.load_mode);
+
+    if (!desc.settings_desc.empty())
+    {
+        auto arr = Das::Utils::MakeYyjsonArray();
+        auto arr_ref = arr.as_array();
+        if (arr_ref)
+        {
+            for (const auto& s : desc.settings_desc)
+            {
+                arr_ref->emplace_back(PluginSettingDescToJson(s));
+            }
+        }
+        (*obj)[std::string_view("settingsDesc")] = std::move(arr);
+    }
+
+    if (!desc.settings_groups.empty())
+    {
+        auto settings_obj = Das::Utils::MakeYyjsonObject();
+        auto settings_ref = settings_obj.as_object();
+        if (settings_ref)
+        {
+            for (const auto& [guid, group] : desc.settings_groups)
+            {
+                auto group_obj = Das::Utils::MakeYyjsonObject();
+                auto group_ref = group_obj.as_object();
+                if (!group_ref)
+                {
+                    continue;
+                }
+                (*group_ref)[std::string_view("name")] = std::make_pair(
+                    std::string_view(group.name),
+                    yyjson::copy_string);
+                (*group_ref)[std::string_view("description")] = std::make_pair(
+                    std::string_view(group.description),
+                    yyjson::copy_string);
+
+                if (!group.descriptors.empty())
+                {
+                    auto d_arr = Das::Utils::MakeYyjsonArray();
+                    auto d_arr_ref = d_arr.as_array();
+                    if (d_arr_ref)
+                    {
+                        for (const auto& d : group.descriptors)
+                        {
+                            d_arr_ref->emplace_back(PluginSettingDescToJson(d));
+                        }
+                    }
+                    (*group_ref)[std::string_view("descriptors")] =
+                        std::move(d_arr);
+                }
+
+                auto guid_str = DasGuidToStdString(guid);
+                (*settings_ref)[std::string_view(guid_str)] =
+                    std::move(group_obj);
+            }
+        }
+        (*obj)[std::string_view("settings")] = std::move(settings_obj);
+    }
+
+    if (!desc.task_descriptors.empty())
+    {
+        auto tasks_obj = Das::Utils::MakeYyjsonObject();
+        auto tasks_ref = tasks_obj.as_object();
+        if (tasks_ref)
+        {
+            for (const auto& [task_guid, task] : desc.task_descriptors)
+            {
+                auto task_obj = Das::Utils::MakeYyjsonObject();
+                auto task_ref = task_obj.as_object();
+                if (!task_ref)
+                {
+                    continue;
+                }
+                (*task_ref)[std::string_view("pluginGuid")] =
+                    DasGuidToStdString(task.plugin_guid);
+                (*task_ref)[std::string_view("name")] = std::make_pair(
+                    std::string_view(task.name),
+                    yyjson::copy_string);
+                (*task_ref)[std::string_view("description")] = std::make_pair(
+                    std::string_view(task.description),
+                    yyjson::copy_string);
+
+                if (task.game_name.has_value())
+                {
+                    (*task_ref)[std::string_view("gameName")] = std::make_pair(
+                        std::string_view(task.game_name.value()),
+                        yyjson::copy_string);
+                }
+
+                if (!task.descriptors.empty())
+                {
+                    auto d_arr = Das::Utils::MakeYyjsonArray();
+                    auto d_arr_ref = d_arr.as_array();
+                    if (d_arr_ref)
+                    {
+                        for (const auto& d : task.descriptors)
+                        {
+                            d_arr_ref->emplace_back(PluginSettingDescToJson(d));
+                        }
+                    }
+                    (*task_ref)[std::string_view("descriptors")] =
+                        std::move(d_arr);
+                }
+
+                if (task.authoring.has_value())
+                {
+                    auto auth_obj = Das::Utils::MakeYyjsonObject();
+                    auto auth_ref = auth_obj.as_object();
+                    if (auth_ref)
+                    {
+                        (*auth_ref)[std::string_view("factoryGuid")] =
+                            DasGuidToStdString(task.authoring->factory_guid);
+                        if (!task.authoring->supported_kinds.empty())
+                        {
+                            auto k_arr = Das::Utils::MakeYyjsonArray();
+                            auto k_arr_ref = k_arr.as_array();
+                            if (k_arr_ref)
+                            {
+                                for (const auto& kind :
+                                     task.authoring->supported_kinds)
+                                {
+                                    k_arr_ref->emplace_back(std::string(kind));
+                                }
+                            }
+                            (*auth_ref)[std::string_view("supportedKinds")] =
+                                std::move(k_arr);
+                        }
+                    }
+                    (*task_ref)[std::string_view("authoring")] =
+                        std::move(auth_obj);
+                }
+
+                if (task.execution_component.has_value())
+                {
+                    auto exec_obj = Das::Utils::MakeYyjsonObject();
+                    auto exec_ref = exec_obj.as_object();
+                    if (exec_ref)
+                    {
+                        (*exec_ref)[std::string_view("componentGuid")] =
+                            DasGuidToStdString(
+                                task.execution_component->component_guid);
+                    }
+                    (*task_ref)[std::string_view("executionComponent")] =
+                        std::move(exec_obj);
+                }
+
+                auto guid_str = DasGuidToStdString(task_guid);
+                (*tasks_ref)[std::string_view(guid_str)] = std::move(task_obj);
+            }
+        }
+        (*obj)[std::string_view("tasks")] = std::move(tasks_obj);
+    }
+
+    if (desc.task_components.has_value())
+    {
+        auto tc_obj = Das::Utils::MakeYyjsonObject();
+        auto tc_ref = tc_obj.as_object();
+        if (tc_ref)
+        {
+            if (desc.task_components->factories.has_value()
+                && !desc.task_components->factories->empty())
+            {
+                auto f_arr = Das::Utils::MakeYyjsonArray();
+                auto f_arr_ref = f_arr.as_array();
+                if (f_arr_ref)
+                {
+                    for (const auto& f :
+                         desc.task_components->factories.value())
+                    {
+                        f_arr_ref->emplace_back(std::string(f));
+                    }
+                }
+                (*tc_ref)[std::string_view("factories")] = std::move(f_arr);
+            }
+
+            if (desc.task_components->components.has_value()
+                && !desc.task_components->components->empty())
+            {
+                auto comp_obj = Das::Utils::MakeYyjsonObject();
+                auto comp_ref = comp_obj.as_object();
+                if (comp_ref)
+                {
+                    for (const auto& [key, entry] :
+                         desc.task_components->components.value())
+                    {
+                        auto entry_obj = Das::Utils::MakeYyjsonObject();
+                        auto entry_ref = entry_obj.as_object();
+                        if (entry_ref)
+                        {
+                            if (entry.factory_guid.has_value())
+                            {
+                                (*entry_ref)[std::string_view("factoryGuid")] =
+                                    std::make_pair(
+                                        std::string_view(
+                                            entry.factory_guid.value()),
+                                        yyjson::copy_string);
+                            }
+                            if (entry.definition.has_value())
+                            {
+                                (*entry_ref)[std::string_view("definition")] =
+                                    entry.definition.value();
+                            }
+                        }
+                        (*comp_ref)[std::string_view(key)] =
+                            std::move(entry_obj);
+                    }
+                }
+                (*tc_ref)[std::string_view("components")] = std::move(comp_obj);
+            }
+        }
+        (*obj)[std::string_view("taskComponents")] = std::move(tc_obj);
+    }
+
+    return j;
+}
+
 DAS_CORE_FOREIGNINTERFACEHOST_NS_END

--- a/das/Http/src/App.cpp
+++ b/das/Http/src/App.cpp
@@ -218,11 +218,10 @@ namespace Das::Http
                     &init_options);
                 if (DAS::IsFailed(init_cv_result))
                 {
-                    DAS_LOG_ERROR(
-                        DAS_FMT_NS::format(
-                            "Failed to init CV services. result = {}",
-                            init_cv_result)
-                            .c_str());
+                    DAS_LOG_ERROR(DAS_FMT_NS::format(
+                                      "Failed to init CV services. result = {}",
+                                      init_cv_result)
+                                      .c_str());
                     return init_cv_result;
                 }
             }
@@ -309,6 +308,10 @@ namespace Das::Http
             DAS_HTTP_API_PREFIX "plugin/{guid}/delete",
             [plugin_controller](const Das::Http::Beast::HttpRequest& req)
             { return plugin_controller->DeletePlugin(req); });
+        components.router->Post(
+            DAS_HTTP_API_PREFIX "plugin/{guid}/detail",
+            [plugin_controller](const Das::Http::Beast::HttpRequest& req)
+            { return plugin_controller->GetPluginDetail(req); });
 
         // Settings
         components.router->Post(
@@ -386,8 +389,7 @@ namespace Das::Http
         components.router->Post(
             DAS_HTTP_API_PREFIX
             "scheduler/{profile}/{taskId}/internal/properties/update",
-            [scheduler_controller](const Das::Http::Beast::HttpRequest& req)
-            {
+            [scheduler_controller](const Das::Http::Beast::HttpRequest& req) {
                 return scheduler_controller->UpdateTaskInternalProperties(req);
             });
         components.router->Post(
@@ -482,11 +484,10 @@ namespace Das::Http
         const auto shutdown_result = components.core_services->Shutdown();
         if (DAS::IsFailed(shutdown_result))
         {
-            DAS_LOG_ERROR(
-                DAS_FMT_NS::format(
-                    "Failed to shutdown CoreServices. result = {}",
-                    shutdown_result)
-                    .c_str());
+            DAS_LOG_ERROR(DAS_FMT_NS::format(
+                              "Failed to shutdown CoreServices. result = {}",
+                              shutdown_result)
+                              .c_str());
         }
 
         // Shutdown IPC context

--- a/das/Http/src/controller/DasPluginManagerController.hpp
+++ b/das/Http/src/controller/DasPluginManagerController.hpp
@@ -126,6 +126,63 @@ namespace Das::Http
             return Beast::HttpResponse::CreateSuccessResponse();
         }
 
+        // POST /plugin/{guid}/detail
+        Beast::HttpResponse GetPluginDetail(const Beast::HttpRequest& request)
+        {
+            auto guid_str = request.GetPathParameter("guid");
+            if (guid_str.empty())
+            {
+                return Beast::HttpResponse::CreateErrorResponse(
+                    DAS_E_INVALID_ARGUMENT,
+                    "Missing GUID path parameter");
+            }
+
+            DasGuid guid;
+            auto    guid_cr = DasMakeDasGuid(guid_str.c_str(), &guid);
+            if (DAS::IsFailed(guid_cr))
+            {
+                return Beast::HttpResponse::CreateErrorResponse(
+                    DAS_E_INVALID_ARGUMENT,
+                    "Invalid GUID format");
+            }
+
+            DasPtr<Das::ExportInterface::IDasJson> json;
+            auto result = plugin_manager_service_.GetPluginPackageDetail(
+                &guid,
+                json.Put());
+            if (DAS::IsFailed(result))
+            {
+                return Beast::HttpResponse::CreateErrorResponse(
+                    result,
+                    "Failed to get plugin detail");
+            }
+
+            DasPtr<IDasReadOnlyString> p_str;
+            auto to_str_result = json->ToString(-1, p_str.Put());
+            if (DAS::IsFailed(to_str_result))
+            {
+                return Beast::HttpResponse::CreateErrorResponse(
+                    to_str_result,
+                    "Failed to serialize plugin detail");
+            }
+            const char* c_str = nullptr;
+            auto        get_result = p_str->GetUtf8(&c_str);
+            if (DAS::IsFailed(get_result))
+            {
+                return Beast::HttpResponse::CreateErrorResponse(
+                    get_result,
+                    "Failed to get plugin detail string");
+            }
+            auto parsed = Das::Utils::ParseYyjsonFromString(c_str);
+            if (!parsed)
+            {
+                return Beast::HttpResponse::CreateErrorResponse(
+                    DAS_E_INVALID_JSON,
+                    "Failed to parse plugin detail JSON");
+            }
+            return Beast::HttpResponse::CreateSuccessResponse(parsed.value());
+        }
+
     private:
         IDasPluginManagerService& plugin_manager_service_;
     };

--- a/include/das/IDasPluginManagerService.h
+++ b/include/das/IDasPluginManagerService.h
@@ -50,6 +50,11 @@ DAS_INTERFACE IDasPluginManagerService : public IDasBase
         const DasGuid* p_component_iid,
         IDasBase**     pp_out_component) = 0;
 
+    // Get full detail of a plugin package by GUID (hides PluginPackageDesc)
+    DAS_METHOD GetPluginPackageDetail(
+        const DasGuid*                   p_package_guid,
+        Das::ExportInterface::IDasJson** pp_out_detail) = 0;
+
     // Get settings field names for a plugin (hides PluginPackageDesc)
     DAS_METHOD GetPluginSettingsFieldNames(
         const DasGuid*                           p_plugin_guid,


### PR DESCRIPTION
Summary
新增通过插件 GUID 获取插件包完整详情的能力，供前端 UI 展示插件配置、任务描述等详细信息。
Changes
接口层

IDasPluginManagerService 新增虚方法 GetPluginPackageDetail(Guid, out IDasJson)
核心实现
PluginManagerServiceImpl::GetPluginPackageDetail — 按 GUID 扫描已安装插件，找到后调用详情序列化
PluginScanner::PluginPackageDescDetailToJson — 在基础 PluginPackageDescToJson 之上扩展，序列化以下字段：
loadMode — 插件加载模式
settingsDesc — 插件级设置描述列表
settings — 按组件 GUID 分组的设置组（含 name、description、descriptors）
tasks — 任务描述（含 name、description、gameName、authoring、executionComponent）
taskComponents — 任务组件（factories + components 映射）
PluginSettingDescToJson — 序列化单个设置项（name、type、required、defaultValue、enumValues 等）
HTTP 层
DasPluginManagerController::GetPluginDetail — 新增 HTTP handler，解析路径中的 GUID 参数
App.cpp 注册路由 POST api/v1/plugin/{guid}/detail
API
POST /api/v1/plugin/{guid}/detail
路径参数：
guid — 插件包 GUID（如 383C85E9-BD34-8D85-AF24-6FE96FE9B000）
成功响应： 插件详情 JSON 对象
错误码：
DAS_E_INVALID_ARGUMENT — GUID 为空或格式错误
DAS_E_NOT_FOUND — 未找到匹配的插件包****