### PR TITLE
feat(graph-authoring): DAS-77 graph 侧 formSequence+graph authoring + 无损升级（thing 3）

### DIFF
--- a/das/Core/GraphRuntime/include/das/Core/GraphRuntime/AuthoringDocContract.h
+++ b/das/Core/GraphRuntime/include/das/Core/GraphRuntime/AuthoringDocContract.h
@@ -124,18 +124,18 @@ namespace Contract
     AuthoringDocument ToAuthoringDocument(const Dto::GraphDocumentDto& document);
 
     // -----------------------------------------------------------------------
-    // Upgrade (formSequence → graph) — lossless, in-place on the store
+    // Upgrade (formSequence → graph) — one-way, lossless, in-place on the store
     // -----------------------------------------------------------------------
+    // Downgrade (graph → formSequence) is intentionally NOT supported: once a
+    // document uses non-linear graph features (branches / merges) it cannot be
+    // represented as a single linear chain, so the reverse direction is not a
+    // valid product operation (dusk.11th 2026-06-30 拍板).
 
     /// Remove the linear marker tag so the document projects to kind == Graph.
-    /// The store is otherwise untouched → the upgrade is lossless and
-    /// reversible (re-adding the tag restores the formSequence view). Returns
-    /// true if the tag was present and removed.
+    /// The store is otherwise untouched → the upgrade is lossless. One-way:
+    /// there is no DowngradeToFormSequence. Returns true if the tag was present
+    /// and removed.
     bool UpgradeToGraph(Dto::GraphDocumentDto& document) noexcept;
-
-    /// Re-add the linear marker tag (graph → formSequence downgrade). Returns
-    /// true if the tag was absent and added.
-    bool DowngradeToFormSequence(Dto::GraphDocumentDto& document) noexcept;
 
     // -----------------------------------------------------------------------
     // Serialization (contract -> yyjson), for the ABI boundary to wrap as JSON

--- a/das/Core/GraphRuntime/include/das/Core/GraphRuntime/AuthoringDocContract.h
+++ b/das/Core/GraphRuntime/include/das/Core/GraphRuntime/AuthoringDocContract.h
@@ -151,6 +151,80 @@ namespace Contract
     /// the caller for writing. (Without copy_string yyjson would point at the
     /// std::string buffers of a local that dies on return → use-after-free.)
     yyjson::value SerializeDocument(const Dto::GraphDocumentDto& document);
+
+    // -----------------------------------------------------------------------
+    // Authoring change — dual-state dispatch on the authoritative store
+    // -----------------------------------------------------------------------
+    //
+    // Mirrors the schema-draft AuthoringChange (`op` + payload fields). The
+    // store's current mode decides how the change is applied:
+    //
+    //   - Graph mode (no linear tag): graph ops (addNode / removeNode /
+    //     connectPorts / disconnectPorts / updateNodeConfig) are delegated to
+    //     the GraphAuthoring engine (ApplySettingsChange) — the previously
+    //     dormant authoring library is enabled, NOT rewritten.
+    //   - Linear mode (formsequence tag): sequence ops (addSequenceItem /
+    //     moveSequenceItem / removeSequenceItem / setValue) are reverse-
+    //     projected onto a FormSequenceDto, applied via FormSequenceProjector
+    //     (reusing its tested mutation logic), then re-projected back onto the
+    //     GraphDocumentDto store (signal chain rebuilt). The store identity
+    //     (document_id / fingerprint / tags) is preserved; revision bumps on
+    //     success.
+    //
+    // `setValue` works in both modes (updates a node's settings by node_id).
+    // On failure the store is left unmodified.
+    // -----------------------------------------------------------------------
+
+    struct AuthoringChange
+    {
+        std::string op; // schema op name (see AuthoringChange.ops in the schema)
+        // addNode (graph)
+        std::optional<GraphNode> node;
+        // removeNode / updateNodeConfig / setValue / removeSequenceItem — id
+        std::string node_id;
+        // connectPorts (graph) — full connection; disconnectPorts — endpoints
+        std::optional<GraphConnection> connection;
+        // updateNodeConfig / setValue — new settings
+        yyjson::value settings;
+        // addSequenceItem / insertSequenceItem
+        std::optional<SequenceItem> item;
+        // moveSequenceItem
+        std::optional<std::size_t> from;
+        std::optional<std::size_t> to;
+    };
+
+    enum class ChangeErrorKind
+    {
+        None,
+        InvalidOp,
+        NodeNotFound,
+        DuplicateNodeId,
+        EmptyNodeId,
+        InvalidEdge,
+        EdgeNotFound,
+        ItemNotFound,
+        InvalidIndex,
+        NoChange,
+    };
+
+    struct AuthoringChangeResult
+    {
+        ChangeErrorKind error_kind = ChangeErrorKind::None;
+        std::string    message;
+
+        [[nodiscard]]
+        bool Ok() const noexcept
+        {
+            return error_kind == ChangeErrorKind::None;
+        }
+    };
+
+    /// Apply a contract change to the authoritative store in place. On success
+    /// bumps `document.version` and returns {None, ""}; on failure leaves the
+    /// store unmodified and returns the error.
+    AuthoringChangeResult ApplyAuthoringChange(
+        Dto::GraphDocumentDto&   document,
+        const AuthoringChange&   change);
 } // namespace Contract
 
 DAS_CORE_GRAPHRUNTIME_NS_END

--- a/das/Core/GraphRuntime/include/das/Core/GraphRuntime/AuthoringDocContract.h
+++ b/das/Core/GraphRuntime/include/das/Core/GraphRuntime/AuthoringDocContract.h
@@ -1,0 +1,217 @@
+#ifndef DAS_CORE_GRAPHRUNTIME_AUTHORINGDOCCONTRACT_H
+#define DAS_CORE_GRAPHRUNTIME_AUTHORINGDOCCONTRACT_H
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <cpp_yyjson.hpp>
+#include <das/Core/GraphRuntime/Config.h>
+#include <das/Core/GraphRuntime/GraphDocument.h>
+
+DAS_CORE_GRAPHRUNTIME_NS_BEGIN
+
+// ---------------------------------------------------------------------------
+// AuthoringDocContract (DAS-77)
+// ---------------------------------------------------------------------------
+//
+// The external-facing authoring document contract — the stable shape exposed
+// across the session ABI boundary. It mirrors the TaskAuthoringHttpContract
+// schema draft (AuthoringDocument / GraphNode / GraphConnection /
+// SequenceItem), NOT the internal GraphDocumentDto. GraphDocumentDto remains
+// the session's authoritative primary store; this contract is its public
+// projection.
+//
+// The contract deliberately drops runtime-private fields:
+//   - GraphEdgeDto::edge_id        (not in GraphConnection)
+//   - GraphEdgeDto::edge_type      (signal/data is a runtime concern)
+//   - GraphNodeDto::dynamic_ports  (runtime port binding)
+//   - GraphNodeDto::target_kind / entry_ref internals (componentGuid only)
+//
+// kind dispatch:
+//   - kind == FormSequence  ⇔  the GraphDocumentDto carries the linear marker
+//                               tag (kLinearTag). GetDocument then reverse-
+//                               projects the linear signal chain into a flat
+//                               SequenceItem[] (a view of the same store).
+//   - kind == Graph         ⇔  the GraphDocumentDto is in canvas mode (no
+//                               linear tag). GetDocument thin-maps nodes and
+//                               connections, dropping the private fields.
+// ---------------------------------------------------------------------------
+
+namespace Contract
+{
+    /// Linear-state marker carried on GraphDocumentDto::tags. A document with
+    /// this tag projects to kind == FormSequence; without it, kind == Graph.
+    inline constexpr std::string_view kLinearTag = "formsequence";
+
+    /// One canvas node in the public contract. componentGuid is sourced from
+    /// the internal target.component_ref.component_guid; dynamic_ports and
+    /// target internals are dropped.
+    struct GraphNode
+    {
+        std::string   id;
+        std::string   component_guid;
+        yyjson::value settings;
+    };
+
+    /// One canvas connection in the public contract. edge_id and edge_type are
+    /// runtime-private and intentionally absent.
+    struct GraphConnection
+    {
+        std::string from_node_id;
+        std::string from_port_id;
+        std::string to_node_id;
+        std::string to_port_id;
+    };
+
+    /// One step in a linear formSequence view. `type` is the component kind
+    /// (component_guid / entry kind) — a UI-facing label, not a runtime field.
+    /// (Nested `children` from the schema draft is intentionally omitted for
+    /// the flat linear projection; it can be added when nesting is needed.)
+    struct SequenceItem
+    {
+        std::string   id;
+        std::string   type;
+        yyjson::value settings;
+    };
+
+    /// The formSequence projection of a linear GraphDocumentDto.
+    struct FormSequenceView
+    {
+        std::vector<SequenceItem> sequence;
+    };
+
+    /// The canvas projection of a GraphDocumentDto.
+    struct GraphView
+    {
+        std::vector<GraphNode>      nodes;
+        std::vector<GraphConnection> connections;
+    };
+
+    enum class Kind
+    {
+        FormSequence,
+        Graph,
+    };
+
+    /// The public authoring document. `kind` decides which of form_sequence /
+    /// graph is populated.
+    struct AuthoringDocument
+    {
+        int32_t                          contract_version = 1;
+        Kind                             kind = Kind::Graph;
+        int32_t                          revision = 0;
+        std::string                      source_fingerprint;
+        std::optional<FormSequenceView>  form_sequence;
+        std::optional<GraphView>         graph;
+    };
+
+    // -----------------------------------------------------------------------
+    // Projection: GraphDocumentDto (internal, authoritative) -> contract
+    // -----------------------------------------------------------------------
+
+    /// True when the document carries the linear marker tag.
+    [[nodiscard]]
+    bool IsLinear(const Dto::GraphDocumentDto& document) noexcept;
+
+    /// Project the authoritative store into the public contract.
+    ///   - Linear (tagged)  → kind == FormSequence; reverse-projects the linear
+    ///                         signal chain into a flat SequenceItem[].
+    ///   - Canvas (untagged)→ kind == Graph; thin-maps nodes/connections,
+    ///                         dropping runtime-private fields.
+    AuthoringDocument ToAuthoringDocument(const Dto::GraphDocumentDto& document);
+
+    // -----------------------------------------------------------------------
+    // Upgrade (formSequence → graph) — lossless, in-place on the store
+    // -----------------------------------------------------------------------
+
+    /// Remove the linear marker tag so the document projects to kind == Graph.
+    /// The store is otherwise untouched → the upgrade is lossless and
+    /// reversible (re-adding the tag restores the formSequence view). Returns
+    /// true if the tag was present and removed.
+    bool UpgradeToGraph(Dto::GraphDocumentDto& document) noexcept;
+
+    /// Re-add the linear marker tag (graph → formSequence downgrade). Returns
+    /// true if the tag was absent and added.
+    bool DowngradeToFormSequence(Dto::GraphDocumentDto& document) noexcept;
+
+    // -----------------------------------------------------------------------
+    // Serialization (contract -> yyjson), for the ABI boundary to wrap as JSON
+    // -----------------------------------------------------------------------
+
+    /// Serialize the authoritative store into the public contract JSON value
+    /// (camelCase keys, per the schema draft). Maps the store directly into a
+    /// serializable shape, then builds the yyjson document with
+    /// `yyjson::copy_string` so every string payload (id, componentGuid, …) is
+    /// deep-copied into the document arena. The returned yyjson::value is
+    /// therefore self-contained — it owns its document and references no
+    /// outside storage — and is safe to return across the boundary / hand to
+    /// the caller for writing. (Without copy_string yyjson would point at the
+    /// std::string buffers of a local that dies on return → use-after-free.)
+    yyjson::value SerializeDocument(const Dto::GraphDocumentDto& document);
+} // namespace Contract
+
+DAS_CORE_GRAPHRUNTIME_NS_END
+
+// ---------------------------------------------------------------------------
+// yyjson (de)serialization support for the contract value types
+// ---------------------------------------------------------------------------
+
+#ifndef DAS_GRAPHRUNTIME_CONTRACT_CASTER
+#define DAS_GRAPHRUNTIME_CONTRACT_CASTER(DtoType)                              \
+    template <>                                                                \
+    struct yyjson::caster<Das::Core::GraphRuntime::Contract::DtoType>          \
+    {                                                                          \
+        template <yyjson::json_value Json>                                     \
+        static Das::Core::GraphRuntime::Contract::DtoType from_json(           \
+            const Json& json)                                                  \
+        {                                                                      \
+            auto object = json.as_object();                                    \
+            if (!object.has_value())                                           \
+            {                                                                  \
+                throw yyjson::bad_cast(                                        \
+                    "Contract type is not constructible from non-object JSON");\
+            }                                                                  \
+            return yyjson::detail::default_caster<                             \
+                Das::Core::GraphRuntime::Contract::DtoType>::from_json(*object);\
+        }                                                                      \
+    }
+#endif
+
+DAS_GRAPHRUNTIME_CONTRACT_CASTER(GraphNode);
+DAS_GRAPHRUNTIME_CONTRACT_CASTER(GraphConnection);
+DAS_GRAPHRUNTIME_CONTRACT_CASTER(FormSequenceView);
+DAS_GRAPHRUNTIME_CONTRACT_CASTER(GraphView);
+
+#undef DAS_GRAPHRUNTIME_CONTRACT_CASTER
+
+template <>
+struct yyjson::field_name_rule<Das::Core::GraphRuntime::Contract::GraphNode>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+template <>
+struct yyjson::field_name_rule<Das::Core::GraphRuntime::Contract::GraphConnection>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+template <>
+struct yyjson::field_name_rule<Das::Core::GraphRuntime::Contract::SequenceItem>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+template <>
+struct yyjson::field_name_rule<
+    Das::Core::GraphRuntime::Contract::FormSequenceView>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+template <>
+struct yyjson::field_name_rule<Das::Core::GraphRuntime::Contract::GraphView>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+
+#endif // DAS_CORE_GRAPHRUNTIME_AUTHORINGDOCCONTRACT_H

--- a/das/Core/GraphRuntime/include/das/Core/GraphRuntime/GraphRuntimeFactory.h
+++ b/das/Core/GraphRuntime/include/das/Core/GraphRuntime/GraphRuntimeFactory.h
@@ -47,4 +47,62 @@ DAS_C_API DasResult CreateGraphRuntimeWithHost(
     Das::PluginInterface::IDasTaskComponentHost* p_host,
     Das::ExportInterface::IDasGraphRuntime**     pp_out_runtime);
 
+// ---------------------------------------------------------------------------
+// Stateful authoring session C ABI (DAS-77)
+// ---------------------------------------------------------------------------
+// The authoritative store (GraphDocumentDto) lives in Core behind an opaque
+// handle; plugins (which only link the stable C ABI) hold the handle and call
+// these per GetDocument / ApplyChange / Compile. The store's public projection
+// is the schema-contract authoring doc (AuthoringDocContract) — GraphDocumentDto
+// never crosses the boundary.
+//
+// Inputs are UTF-8 JSON strings (IDasReadOnlyString); outputs are IDasJson.
+// ---------------------------------------------------------------------------
+
+/// Opaque Core-owned authoring session state (holds the GraphDocumentDto).
+struct GraphAuthoringSessionState;
+
+/// Create a session seeded from a context JSON. The context may be:
+///   - a formSequence document ({ "items": [...] }) → projected to a linear
+///     GraphDocumentDto and tagged "formsequence";
+///   - a graph document ({ "nodes": [...], "edges": [...] }) → parsed directly;
+///   - anything else / null → an empty (graph-mode) store.
+DAS_C_API DasResult CreateGraphAuthoringSession(
+    IDasReadOnlyString*             p_context_json,
+    GraphAuthoringSessionState**    pp_out);
+
+/// Destroy a session and release its store. Safe on null.
+DAS_C_API void DestroyGraphAuthoringSession(GraphAuthoringSessionState* p);
+
+/// GetDocument: emit the schema-contract authoring doc for the current store
+/// (formSequence view when linear-tagged, graph view otherwise). The runtime
+/// GraphDocumentDto never leaks.
+DAS_C_API DasResult GraphAuthoringSessionGetDocument(
+    GraphAuthoringSessionState*         p,
+    IDasReadOnlyString*                 p_request_json,
+    Das::ExportInterface::IDasJson**    pp_out_document_json);
+
+/// ApplyChange: parse a contract change JSON, dispatch the dual-state
+/// ApplyAuthoringChange on the store, and return an authoring-result JSON
+/// ({ "ok":bool, "revision":int, "errorKind"?:string, "message"?:string }).
+DAS_C_API DasResult GraphAuthoringSessionApplyChange(
+    GraphAuthoringSessionState*         p,
+    IDasReadOnlyString*                 p_change_json,
+    Das::ExportInterface::IDasJson**    pp_out_result_json);
+
+/// Compile: compile the store into a CompiledGraphPlanDto JSON — the execution
+/// artifact consumed by DasGraphTaskImpl::Do() / IDasGraphRuntime::Execute().
+/// Port validation is skipped at the authoring boundary (no factory manager
+/// bound); acceptable for authoring preview.
+DAS_C_API DasResult GraphAuthoringSessionCompile(
+    GraphAuthoringSessionState*         p,
+    IDasReadOnlyString*                 p_request_json,
+    Das::ExportInterface::IDasJson**    pp_out_compiled_plan_json);
+
+/// Upgrade the store from formSequence (linear) to graph (canvas) view —
+/// lossless (only the linear tag is removed). Returns DAS_E_FAIL if the store
+/// is not in linear mode.
+DAS_C_API DasResult GraphAuthoringSessionUpgradeToGraph(
+    GraphAuthoringSessionState* p);
+
 #endif // DAS_CORE_GRAPHRUNTIME_GRAPHRUNTIMEFACTORY_H

--- a/das/Core/GraphRuntime/src/AuthoringDocContract.cpp
+++ b/das/Core/GraphRuntime/src/AuthoringDocContract.cpp
@@ -1,0 +1,323 @@
+#include <das/Core/GraphRuntime/AuthoringDocContract.h>
+
+#include <algorithm>
+#include <cassert>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <das/Utils/DasJsonCore.h>
+
+DAS_CORE_GRAPHRUNTIME_NS_BEGIN
+
+namespace Contract
+{
+    namespace
+    {
+        // -------------------------------------------------------------------
+        // Tag handling
+        // -------------------------------------------------------------------
+
+        bool HasTag(const Dto::GraphDocumentDto& doc, std::string_view tag)
+        {
+            for (const auto& t : doc.tags)
+            {
+                if (t == tag)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void RemoveTag(Dto::GraphDocumentDto& doc, std::string_view tag)
+        {
+            doc.tags.erase(
+                std::remove_if(
+                    doc.tags.begin(),
+                    doc.tags.end(),
+                    [&](const std::string& t) { return t == tag; }),
+                doc.tags.end());
+        }
+
+        // -------------------------------------------------------------------
+        // componentGuid extraction from a node target
+        // -------------------------------------------------------------------
+
+        std::string ComponentGuidOf(const Dto::GraphNodeDto& node)
+        {
+            if (node.target.component_ref.has_value())
+            {
+                return node.target.component_ref->component_guid;
+            }
+            return {};
+        }
+
+        // -------------------------------------------------------------------
+        // Reverse projection: linear signal chain -> SequenceItem[]
+        // -------------------------------------------------------------------
+        //
+        // The linear state is a single signal chain. We recover its order by
+        // walking signal edges: find the head (the node with no incoming
+        // signal edge), then follow signal_out -> signal_in. Non-signal edges
+        // and disconnected nodes are ignored for the sequence ordering; every
+        // node still appears (disconnected ones appended at the tail in array
+        // order so nothing is dropped).
+        // -------------------------------------------------------------------
+
+        std::vector<SequenceItem> ReverseProjectSequence(
+            const Dto::GraphDocumentDto& doc)
+        {
+            std::unordered_map<std::string, std::string> signal_next;
+            std::unordered_set<std::string>              has_incoming;
+
+            for (const auto& node : doc.nodes)
+            {
+                has_incoming.insert(node.node_id);
+            }
+            // has_incoming starts as "all nodes"; we remove heads below by
+            // flagging nodes that ARE signal targets.
+            std::unordered_set<std::string> signal_targets;
+            for (const auto& edge : doc.edges)
+            {
+                if (edge.edge_type != "signal")
+                {
+                    continue;
+                }
+                // First signal edge out of a node wins; the formSequence
+                // projection produces exactly one out per node.
+                signal_next.emplace(edge.source_node_id, edge.target_node_id);
+                signal_targets.insert(edge.target_node_id);
+            }
+
+            std::vector<SequenceItem> items;
+            items.reserve(doc.nodes.size());
+
+            // Head = a node that is never a signal target.
+            std::string head;
+            bool        found_head = false;
+            for (const auto& node : doc.nodes)
+            {
+                if (signal_targets.count(node.node_id) == 0)
+                {
+                    head       = node.node_id;
+                    found_head = true;
+                    break;
+                }
+            }
+
+            std::unordered_set<std::string> visited;
+            auto build_item = [&](const Dto::GraphNodeDto& node)
+            {
+                SequenceItem item;
+                item.id       = node.node_id;
+                item.type     = ComponentGuidOf(node);
+                item.settings = Das::Utils::CloneYyjsonValue(node.settings);
+                items.push_back(std::move(item));
+                visited.insert(node.node_id);
+            };
+
+            if (found_head)
+            {
+                const Dto::GraphNodeDto* cur = nullptr;
+                for (const auto& node : doc.nodes)
+                {
+                    if (node.node_id == head)
+                    {
+                        cur = &node;
+                        break;
+                    }
+                }
+                while (cur != nullptr)
+                {
+                    build_item(*cur);
+                    auto it = signal_next.find(cur->node_id);
+                    if (it == signal_next.end())
+                    {
+                        break;
+                    }
+                    const std::string& next_id = it->second;
+                    cur = nullptr;
+                    for (const auto& node : doc.nodes)
+                    {
+                        if (node.node_id == next_id)
+                        {
+                            cur = &node;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Append any nodes not reachable along the chain (preserves all
+            // nodes so the projection is total — matches Project()'s totality).
+            for (const auto& node : doc.nodes)
+            {
+                if (visited.count(node.node_id) == 0)
+                {
+                    build_item(node);
+                }
+            }
+
+            return items;
+        }
+
+        // -------------------------------------------------------------------
+        // Thin graph mapping (drops runtime-private fields)
+        // -------------------------------------------------------------------
+
+        GraphView MapGraphView(const Dto::GraphDocumentDto& doc)
+        {
+            GraphView view;
+            view.nodes.reserve(doc.nodes.size());
+            for (const auto& node : doc.nodes)
+            {
+                GraphNode out;
+                out.id              = node.node_id;
+                out.component_guid  = ComponentGuidOf(node);
+                out.settings        = Das::Utils::CloneYyjsonValue(node.settings);
+                view.nodes.push_back(std::move(out));
+            }
+
+            view.connections.reserve(doc.edges.size());
+            for (const auto& edge : doc.edges)
+            {
+                GraphConnection out;
+                out.from_node_id = edge.source_node_id;
+                out.from_port_id = edge.source_port_id;
+                out.to_node_id   = edge.target_node_id;
+                out.to_port_id   = edge.target_port_id;
+                // edge_id and edge_type are deliberately dropped — they are
+                // runtime-private and must NOT leak across the ABI boundary.
+                view.connections.push_back(std::move(out));
+            }
+            return view;
+        }
+    } // anonymous namespace
+
+    // -------------------------------------------------------------------
+    // Serializable JSON-shape aggregates. Declared at Contract namespace scope
+    // (NOT anonymous) because boost::pfr aggregate reflection rejects
+    // local/anonymous-namespace types. camelCase member names emit the
+    // schema-draft keys directly via yyjson reflection; no field_name_rule.
+    // -------------------------------------------------------------------
+
+    struct FormSequenceDocShape
+    {
+        int32_t          contract_version = 1;
+        std::string      kind{"formSequence"};
+        int32_t          revision = 0;
+        std::string      source_fingerprint;
+        FormSequenceView form_sequence;
+    };
+
+    struct GraphDocShape
+    {
+        int32_t     contract_version = 1;
+        std::string kind{"graph"};
+        int32_t     revision = 0;
+        std::string source_fingerprint;
+        GraphView   graph;
+    };
+
+    // field_name_rule for the shapes — declared after the complete type and
+    // before Serialize instantiates yyjson::object(shape).
+} // namespace Contract
+DAS_CORE_GRAPHRUNTIME_NS_END
+
+template <>
+struct yyjson::field_name_rule<
+    Das::Core::GraphRuntime::Contract::FormSequenceDocShape>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+template <>
+struct yyjson::field_name_rule<
+    Das::Core::GraphRuntime::Contract::GraphDocShape>
+{
+    using type = yyjson::snake_to_camel_transform;
+};
+
+DAS_CORE_GRAPHRUNTIME_NS_BEGIN
+namespace Contract
+{
+
+    // -------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------
+
+    bool IsLinear(const Dto::GraphDocumentDto& document) noexcept
+    {
+        return HasTag(document, kLinearTag);
+    }
+
+    AuthoringDocument ToAuthoringDocument(const Dto::GraphDocumentDto& document)
+    {
+        AuthoringDocument out;
+        out.revision          = document.version;
+        out.source_fingerprint = document.fingerprint;
+
+        if (IsLinear(document))
+        {
+            out.kind = Kind::FormSequence;
+            FormSequenceView view;
+            view.sequence = ReverseProjectSequence(document);
+            out.form_sequence = std::move(view);
+        }
+        else
+        {
+            out.kind = Kind::Graph;
+            out.graph = MapGraphView(document);
+        }
+        return out;
+    }
+
+    bool UpgradeToGraph(Dto::GraphDocumentDto& document) noexcept
+    {
+        if (!IsLinear(document))
+        {
+            return false;
+        }
+        RemoveTag(document, kLinearTag);
+        return true;
+    }
+
+    bool DowngradeToFormSequence(Dto::GraphDocumentDto& document) noexcept
+    {
+        if (IsLinear(document))
+        {
+            return false;
+        }
+        document.tags.emplace_back(kLinearTag);
+        return true;
+    }
+
+    yyjson::value SerializeDocument(const Dto::GraphDocumentDto& document)
+    {
+        // Build the serialisable shape and create the yyjson document with
+        // yyjson::copy_string: string payloads are deep-copied into the
+        // document's own arena, so the returned value is self-contained and
+        // safe to return / write after the local shape is gone. (Without
+        // copy_string yyjson would reference the std::string buffers of the
+        // local shape → use-after-free on write.)
+        if (IsLinear(document))
+        {
+            FormSequenceDocShape shape;
+            shape.contract_version   = 1;
+            shape.revision           = document.version;
+            shape.source_fingerprint = document.fingerprint;
+            shape.form_sequence.sequence = ReverseProjectSequence(document);
+            return yyjson::object(shape, yyjson::copy_string);
+        }
+        GraphDocShape shape;
+        shape.contract_version   = 1;
+        shape.revision           = document.version;
+        shape.source_fingerprint = document.fingerprint;
+        shape.graph              = MapGraphView(document);
+        return yyjson::object(shape, yyjson::copy_string);
+    }
+} // namespace Contract
+
+DAS_CORE_GRAPHRUNTIME_NS_END

--- a/das/Core/GraphRuntime/src/AuthoringDocContract.cpp
+++ b/das/Core/GraphRuntime/src/AuthoringDocContract.cpp
@@ -286,16 +286,6 @@ namespace Contract
         return true;
     }
 
-    bool DowngradeToFormSequence(Dto::GraphDocumentDto& document) noexcept
-    {
-        if (IsLinear(document))
-        {
-            return false;
-        }
-        document.tags.emplace_back(kLinearTag);
-        return true;
-    }
-
     yyjson::value SerializeDocument(const Dto::GraphDocumentDto& document)
     {
         // Build the serialisable shape and create the yyjson document with
@@ -593,6 +583,16 @@ namespace Contract
 
             // Re-project the mutated sequence back onto the store, preserving
             // identity (tags / fingerprint). version is bumped by the caller.
+            //
+            // PREMISE: a linear (formsequence) document is a single signal
+            // chain — it carries no non-signal structure. Project() rebuilds
+            // nodes + the linear signal edges from scratch, so any non-signal
+            // data edges that hypothetically existed on the store are dropped
+            // by this full rebuild. That is correct for the linear mode: a
+            // document that needed non-signal edges would not be linear and
+            // would be in graph mode (where GraphAuthoring mutates in place
+            // and never comes through this path). Do not route a non-linear
+            // document through linear-mode changes.
             auto rebuilt = FormSequenceProjector::Project(seq);
             rebuilt.tags       = std::move(document.tags);
             rebuilt.fingerprint = document.fingerprint;

--- a/das/Core/GraphRuntime/src/AuthoringDocContract.cpp
+++ b/das/Core/GraphRuntime/src/AuthoringDocContract.cpp
@@ -8,6 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <das/Core/GraphRuntime/FormSequenceProjector.h>
+#include <das/Core/GraphRuntime/GraphAuthoring.h>
 #include <das/Utils/DasJsonCore.h>
 
 DAS_CORE_GRAPHRUNTIME_NS_BEGIN
@@ -317,6 +319,300 @@ namespace Contract
         shape.source_fingerprint = document.fingerprint;
         shape.graph              = MapGraphView(document);
         return yyjson::object(shape, yyjson::copy_string);
+    }
+
+    // -------------------------------------------------------------------
+    // Authoring change dispatch
+    // -------------------------------------------------------------------
+
+    namespace
+    {
+        using FormSeqDto  = Dto::FormSequenceDto;
+        using FormSeqItem = Dto::FormSequenceItemDto;
+
+        /// Ordered node ids of a linear signal chain (head → tail), then any
+        /// disconnected nodes in array order. Shared by the reverse projections.
+        std::vector<std::string> LinearOrder(const Dto::GraphDocumentDto& doc)
+        {
+            std::unordered_map<std::string, std::string> signal_next;
+            std::unordered_set<std::string>              signal_targets;
+            for (const auto& edge : doc.edges)
+            {
+                if (edge.edge_type != "signal")
+                {
+                    continue;
+                }
+                signal_next.emplace(edge.source_node_id, edge.target_node_id);
+                signal_targets.insert(edge.target_node_id);
+            }
+
+            std::string head;
+            bool        found_head = false;
+            for (const auto& node : doc.nodes)
+            {
+                if (signal_targets.count(node.node_id) == 0)
+                {
+                    head       = node.node_id;
+                    found_head = true;
+                    break;
+                }
+            }
+
+            std::vector<std::string>      order;
+            std::unordered_set<std::string> visited;
+            auto push = [&](const std::string& id)
+            {
+                order.push_back(id);
+                visited.insert(id);
+            };
+
+            if (found_head)
+            {
+                std::string cur = head;
+                while (!cur.empty() && visited.count(cur) == 0)
+                {
+                    push(cur);
+                    auto it = signal_next.find(cur);
+                    if (it == signal_next.end())
+                    {
+                        break;
+                    }
+                    cur = it->second;
+                }
+            }
+            for (const auto& node : doc.nodes)
+            {
+                if (visited.count(node.node_id) == 0)
+                {
+                    push(node.node_id);
+                }
+            }
+            return order;
+        }
+
+        /// Reverse-project the linear store onto a FormSequenceDto so the
+        /// existing FormSequenceProjector mutation logic can be reused.
+        FormSeqDto GraphToSequence(const Dto::GraphDocumentDto& doc)
+        {
+            FormSeqDto seq;
+            seq.document_id = doc.document_id;
+            seq.version     = doc.version;
+            seq.fingerprint = doc.fingerprint;
+
+            std::unordered_map<std::string, const Dto::GraphNodeDto*> by_id;
+            for (const auto& node : doc.nodes)
+            {
+                by_id.emplace(node.node_id, &node);
+            }
+            for (const auto& id : LinearOrder(doc))
+            {
+                auto it = by_id.find(id);
+                if (it == by_id.end())
+                {
+                    continue;
+                }
+                const auto& node = *it->second;
+                FormSeqItem item;
+                item.item_id = node.node_id;
+                item.target  = node.target;
+                item.settings = Das::Utils::CloneYyjsonValue(node.settings);
+                seq.items.push_back(std::move(item));
+            }
+            return seq;
+        }
+
+        ChangeErrorKind MapGraphError(AuthoringErrorKind k)
+        {
+            switch (k)
+            {
+                case AuthoringErrorKind::None:           return ChangeErrorKind::None;
+                case AuthoringErrorKind::NodeNotFound:   return ChangeErrorKind::NodeNotFound;
+                case AuthoringErrorKind::DuplicateNodeId:return ChangeErrorKind::DuplicateNodeId;
+                case AuthoringErrorKind::EmptyNodeId:    return ChangeErrorKind::EmptyNodeId;
+                case AuthoringErrorKind::InvalidEdge:    return ChangeErrorKind::InvalidEdge;
+                case AuthoringErrorKind::EdgeNotFound:   return ChangeErrorKind::EdgeNotFound;
+                default:                                 return ChangeErrorKind::InvalidEdge;
+            }
+        }
+
+        ChangeErrorKind MapSeqError(FormSequenceErrorKind k)
+        {
+            switch (k)
+            {
+                case FormSequenceErrorKind::None:            return ChangeErrorKind::None;
+                case FormSequenceErrorKind::EmptyItemId:     return ChangeErrorKind::EmptyNodeId;
+                case FormSequenceErrorKind::DuplicateItemId: return ChangeErrorKind::DuplicateNodeId;
+                case FormSequenceErrorKind::ItemNotFound:    return ChangeErrorKind::ItemNotFound;
+                case FormSequenceErrorKind::InvalidIndex:    return ChangeErrorKind::InvalidIndex;
+                case FormSequenceErrorKind::NoChange:        return ChangeErrorKind::NoChange;
+            }
+            return ChangeErrorKind::InvalidOp;
+        }
+
+        /// graph-mode dispatch: delegate to GraphAuthoring::ApplySettingsChange.
+        AuthoringChangeResult ApplyGraphChange(
+            Dto::GraphDocumentDto&  document,
+            const AuthoringChange&  change)
+        {
+            GraphAuthoringChange gac;
+            if (change.op == "addNode")
+            {
+                if (!change.node.has_value())
+                {
+                    return {ChangeErrorKind::InvalidOp, "addNode requires node"};
+                }
+                AddNodeChange c;
+                c.node.node_id = change.node->id;
+                c.node.settings = Das::Utils::CloneYyjsonValue(change.node->settings);
+                c.node.target.target_kind   = "componentRef";
+                c.node.target.component_ref =
+                    Dto::ComponentRefDto{"componentRef", change.node->component_guid, {}};
+                gac.payload = c;
+            }
+            else if (change.op == "removeNode")
+            {
+                gac.payload = RemoveNodeChange{change.node_id};
+            }
+            else if (change.op == "connectPorts")
+            {
+                if (!change.connection.has_value())
+                {
+                    return {ChangeErrorKind::InvalidOp, "connectPorts requires connection"};
+                }
+                const auto& conn = *change.connection;
+                ConnectPortsChange c;
+                c.edge.edge_id        = "edge::" + conn.from_node_id + "::"
+                                        + conn.from_port_id + "::" + conn.to_node_id
+                                        + "::" + conn.to_port_id;
+                c.edge.source_node_id = conn.from_node_id;
+                c.edge.source_port_id = conn.from_port_id;
+                c.edge.target_node_id = conn.to_node_id;
+                c.edge.target_port_id = conn.to_port_id;
+                c.edge.edge_type      = "data";
+                gac.payload = c;
+            }
+            else if (change.op == "disconnectPorts")
+            {
+                if (!change.connection.has_value())
+                {
+                    return {ChangeErrorKind::InvalidOp, "disconnectPorts requires connection"};
+                }
+                const auto& conn = *change.connection;
+                std::string edge_id;
+                for (const auto& edge : document.edges)
+                {
+                    if (edge.source_node_id == conn.from_node_id
+                        && edge.source_port_id == conn.from_port_id
+                        && edge.target_node_id == conn.to_node_id
+                        && edge.target_port_id == conn.to_port_id)
+                    {
+                        edge_id = edge.edge_id;
+                        break;
+                    }
+                }
+                if (edge_id.empty())
+                {
+                    return {ChangeErrorKind::EdgeNotFound,
+                            "no edge matches the given connection endpoints"};
+                }
+                gac.payload = DisconnectPortsChange{edge_id};
+            }
+            else if (change.op == "updateNodeConfig" || change.op == "setValue")
+            {
+                UpdateNodeConfigChange c;
+                c.node_id  = change.node_id;
+                c.settings = Das::Utils::CloneYyjsonValue(change.settings);
+                gac.payload = c;
+            }
+            else
+            {
+                return {ChangeErrorKind::InvalidOp,
+                        "op '" + change.op + "' is not a graph-mode op"};
+            }
+
+            auto r = ApplySettingsChange(document, gac);
+            if (!r.Ok())
+            {
+                return {MapGraphError(r.error_kind), std::move(r.message)};
+            }
+            return {ChangeErrorKind::None, ""};
+        }
+
+        /// linear-mode dispatch: reverse-project → FormSequenceProjector →
+        /// re-project, preserving store identity.
+        AuthoringChangeResult ApplyLinearChange(
+            Dto::GraphDocumentDto&  document,
+            const AuthoringChange&  change)
+        {
+            FormSequenceChange fc;
+            if (change.op == "addSequenceItem")
+            {
+                if (!change.item.has_value())
+                {
+                    return {ChangeErrorKind::InvalidOp, "addSequenceItem requires item"};
+                }
+                AppendSequenceItemChange c;
+                c.item.item_id = change.item->id;
+                c.item.target.target_kind   = "componentRef";
+                c.item.target.component_ref =
+                    Dto::ComponentRefDto{"componentRef", change.item->type, {}};
+                c.item.settings = Das::Utils::CloneYyjsonValue(change.item->settings);
+                fc.payload = c;
+            }
+            else if (change.op == "moveSequenceItem")
+            {
+                if (!change.from.has_value() || !change.to.has_value())
+                {
+                    return {ChangeErrorKind::InvalidOp, "moveSequenceItem requires from/to"};
+                }
+                fc.payload = MoveSequenceItemChange{*change.from, *change.to};
+            }
+            else if (change.op == "removeSequenceItem")
+            {
+                fc.payload = RemoveSequenceItemChange{change.node_id};
+            }
+            else if (change.op == "setValue")
+            {
+                SetSequenceItemValueChange c;
+                c.item_id  = change.node_id;
+                c.settings = Das::Utils::CloneYyjsonValue(change.settings);
+                fc.payload = c;
+            }
+            else
+            {
+                return {ChangeErrorKind::InvalidOp,
+                        "op '" + change.op + "' is not a linear-mode op"};
+            }
+
+            auto seq = GraphToSequence(document);
+            auto r   = FormSequenceProjector::ApplyChange(seq, fc);
+            if (!r.Ok())
+            {
+                return {MapSeqError(r.error_kind), std::move(r.message)};
+            }
+
+            // Re-project the mutated sequence back onto the store, preserving
+            // identity (tags / fingerprint). version is bumped by the caller.
+            auto rebuilt = FormSequenceProjector::Project(seq);
+            rebuilt.tags       = std::move(document.tags);
+            rebuilt.fingerprint = document.fingerprint;
+            document = std::move(rebuilt);
+            return {ChangeErrorKind::None, ""};
+        }
+    } // anonymous namespace
+
+    AuthoringChangeResult ApplyAuthoringChange(
+        Dto::GraphDocumentDto&  document,
+        const AuthoringChange&  change)
+    {
+        AuthoringChangeResult r = IsLinear(document)
+            ? ApplyLinearChange(document, change)
+            : ApplyGraphChange(document, change);
+        if (r.Ok())
+        {
+            ++document.version;
+        }
+        return r;
     }
 } // namespace Contract
 

--- a/das/Core/GraphRuntime/src/GraphRuntimeFactory.cpp
+++ b/das/Core/GraphRuntime/src/GraphRuntimeFactory.cpp
@@ -1,7 +1,14 @@
 #include <das/Core/GraphRuntime/GraphRuntimeFactory.h>
 
+#include <das/Core/ForeignInterfaceHost/TaskComponentFactoryManager.h>
+#include <das/Core/GraphRuntime/AuthoringDocContract.h>
+#include <das/Core/GraphRuntime/FormSequenceProjector.h>
+#include <das/Core/GraphRuntime/GraphAuthoring.h>
+#include <das/Core/GraphRuntime/GraphCompiler.h>
 #include <das/Core/Logger/Logger.h>
 #include <das/DasApi.h>
+#include <das/Utils/DasJsonCore.h>
+#include <cpp_yyjson.hpp>
 #include <new>
 
 DAS_CORE_GRAPHRUNTIME_NS_BEGIN
@@ -135,3 +142,528 @@ DAS_C_API DasResult CreateGraphRuntimeWithHost(
         return DAS_E_OUT_OF_MEMORY;
     }
 }
+
+
+// ============================================================================
+// Stateful authoring session C ABI (DAS-77)
+// ============================================================================
+//
+// The authoritative store (GraphDocumentDto) lives in Core behind an opaque
+// handle. Plugins hold the handle and call these per GetDocument / ApplyChange
+// / Compile. The public projection is the schema-contract authoring doc
+// (AuthoringDocContract); the runtime GraphDocumentDto never crosses.
+// ============================================================================
+
+// The Core-owned authoritative store. Opaque to plugins (forward-declared in
+// the header); full definition lives only here, at global scope to match the
+// header's forward declaration (the C ABI entry points are also global).
+struct GraphAuthoringSessionState
+{
+    Das::Core::GraphRuntime::Dto::GraphDocumentDto document;
+};
+
+namespace
+{
+    namespace GR = Das::Core::GraphRuntime;
+    using FormSeqDto = Das::Core::GraphRuntime::Dto::FormSequenceDto;
+    using GraphDocDto = Das::Core::GraphRuntime::Dto::GraphDocumentDto;
+
+    bool ReadUtf8(IDasReadOnlyString* p_str, std::string& out)
+    {
+        if (p_str == nullptr)
+        {
+            out.clear();
+            return true;
+        }
+        const char* utf8 = nullptr;
+        if (DAS::IsFailed(p_str->GetUtf8(&utf8)) || utf8 == nullptr)
+        {
+            return false;
+        }
+        out = utf8;
+        return true;
+    }
+
+    DasResult
+    WrapValue(const yyjson::value& value, Das::ExportInterface::IDasJson** out)
+    {
+        auto serialized = Das::Utils::SerializeYyjsonValue(value);
+        if (!serialized)
+        {
+            return DAS_E_FAIL;
+        }
+        return ParseDasJsonFromString(serialized->c_str(), out);
+    }
+
+    // -------------------------------------------------------------------
+    // Context seeding
+    // -------------------------------------------------------------------
+
+    /// Read a GraphDocumentDto field-by-field from a JSON object (robust manual
+    /// parse at the boundary; aggregate cast would also work but this avoids
+    /// throwing on partial input).
+    template <typename Obj>
+    bool ParseGraphDoc(const Obj& obj, GraphDocDto& out)
+    {
+        out = GraphDocDto{};
+        if (auto v = obj[std::string_view("documentId")].as_string())
+        {
+            out.document_id = std::string(*v);
+        }
+        if (auto v = obj[std::string_view("version")].as_int())
+        {
+            out.version = static_cast<int32_t>(*v);
+        }
+        if (auto v = obj[std::string_view("fingerprint")].as_string())
+        {
+            out.fingerprint = std::string(*v);
+        }
+        if (obj.contains(std::string_view("nodes")))
+        {
+            auto arr = obj[std::string_view("nodes")].as_array();
+            if (arr)
+            {
+                for (const auto& nv : *arr)
+                {
+                    try
+                    {
+                        out.nodes.push_back(
+                            GR::Dto::Detail::CastDtoObject<
+                                Das::Core::GraphRuntime::Dto::GraphNodeDto>(nv));
+                    }
+                    catch (...)
+                    {
+                        // skip malformed node
+                    }
+                }
+            }
+        }
+        if (obj.contains(std::string_view("edges")))
+        {
+            auto arr = obj[std::string_view("edges")].as_array();
+            if (arr)
+            {
+                for (const auto& ev : *arr)
+                {
+                    try
+                    {
+                        out.edges.push_back(
+                            GR::Dto::Detail::CastDtoObject<
+                                Das::Core::GraphRuntime::Dto::GraphEdgeDto>(ev));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
+        }
+        if (obj.contains(std::string_view("tags")))
+        {
+            auto arr = obj[std::string_view("tags")].as_array();
+            if (arr)
+            {
+                for (const auto& tv : *arr)
+                {
+                    if (auto s = tv.as_string())
+                    {
+                        out.tags.emplace_back(std::string(*s));
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    void SeedFromContext(GraphAuthoringSessionState& s, std::string_view json)
+    {
+        if (json.empty())
+        {
+            return;
+        }
+        yyjson::value root;
+        try
+        {
+            root = yyjson::read(std::string(json));
+        }
+        catch (...)
+        {
+            return;
+        }
+        auto obj = root.as_object();
+        if (!obj)
+        {
+            return;
+        }
+        if (obj->contains(std::string_view("items")))
+        {
+            // formSequence context → project to a linear GraphDocumentDto.
+            FormSeqDto seq;
+            if (auto v = (*obj)[std::string_view("documentId")].as_string())
+            {
+                seq.document_id = std::string(*v);
+            }
+            if (auto v = (*obj)[std::string_view("version")].as_int())
+            {
+                seq.version = static_cast<int32_t>(*v);
+            }
+            if (auto v = (*obj)[std::string_view("fingerprint")].as_string())
+            {
+                seq.fingerprint = std::string(*v);
+            }
+            auto items = (*obj)[std::string_view("items")].as_array();
+            if (items)
+            {
+                for (const auto& iv : *items)
+                {
+                    try
+                    {
+                        seq.items.push_back(
+                            GR::Dto::Detail::CastDtoObject<
+                                Das::Core::GraphRuntime::Dto::FormSequenceItemDto>(iv));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
+            s.document = GR::FormSequenceProjector::Project(seq);
+            s.document.tags.emplace_back(GR::Contract::kLinearTag);
+        }
+        else if (obj->contains(std::string_view("nodes")))
+        {
+            // graph context → parse directly.
+            ParseGraphDoc(*obj, s.document);
+        }
+        // else: leave empty (graph-mode) store.
+    }
+
+    // -------------------------------------------------------------------
+    // Contract change parsing
+    // -------------------------------------------------------------------
+
+    template <typename Obj>
+    bool ReadStringField(
+        const Obj&           obj,
+        std::string_view     key,
+        std::string&         out)
+    {
+        if (!obj.contains(key))
+        {
+            return false;
+        }
+        if (auto v = obj[key].as_string())
+        {
+            out = std::string(*v);
+            return true;
+        }
+        return false;
+    }
+
+    template <typename Obj>
+    std::optional<GR::Contract::GraphNode>
+    ParseGraphNode(const Obj& obj)
+    {
+        GR::Contract::GraphNode node;
+        if (!ReadStringField(obj, std::string_view("id"), node.id))
+        {
+            return std::nullopt;
+        }
+        ReadStringField(obj, std::string_view("componentGuid"), node.component_guid);
+        if (obj.contains(std::string_view("settings")))
+        {
+            node.settings =
+                Das::Utils::CloneYyjsonValue(obj[std::string_view("settings")]);
+        }
+        return node;
+    }
+
+    template <typename Obj>
+    std::optional<GR::Contract::GraphConnection>
+    ParseGraphConnection(const Obj& obj)
+    {
+        GR::Contract::GraphConnection c;
+        if (!ReadStringField(obj, std::string_view("fromNodeId"), c.from_node_id))
+        {
+            return std::nullopt;
+        }
+        ReadStringField(obj, std::string_view("fromPortId"), c.from_port_id);
+        if (!ReadStringField(obj, std::string_view("toNodeId"), c.to_node_id))
+        {
+            return std::nullopt;
+        }
+        ReadStringField(obj, std::string_view("toPortId"), c.to_port_id);
+        return c;
+    }
+
+    template <typename Obj>
+    std::optional<GR::Contract::SequenceItem>
+    ParseSequenceItem(const Obj& obj)
+    {
+        GR::Contract::SequenceItem item;
+        if (!ReadStringField(obj, std::string_view("id"), item.id))
+        {
+            return std::nullopt;
+        }
+        ReadStringField(obj, std::string_view("type"), item.type);
+        if (obj.contains(std::string_view("settings")))
+        {
+            item.settings =
+                Das::Utils::CloneYyjsonValue(obj[std::string_view("settings")]);
+        }
+        return item;
+    }
+
+    bool ParseAuthoringChange(const yyjson::value& json, GR::Contract::AuthoringChange& out)
+    {
+        out = GR::Contract::AuthoringChange{};
+        auto obj = json.as_object();
+        if (!obj)
+        {
+            return false;
+        }
+        if (!ReadStringField(*obj, std::string_view("op"), out.op))
+        {
+            return false;
+        }
+
+        if (obj->contains(std::string_view("node")))
+        {
+            if (auto sub = (*obj)[std::string_view("node")].as_object())
+            {
+                out.node = ParseGraphNode(*sub);
+            }
+        }
+        ReadStringField(*obj, std::string_view("nodeId"), out.node_id);
+        if (obj->contains(std::string_view("connection")))
+        {
+            if (auto sub = (*obj)[std::string_view("connection")].as_object())
+            {
+                out.connection = ParseGraphConnection(*sub);
+            }
+        }
+        if (obj->contains(std::string_view("settings")))
+        {
+            out.settings =
+                Das::Utils::CloneYyjsonValue((*obj)[std::string_view("settings")]);
+        }
+        if (obj->contains(std::string_view("item")))
+        {
+            if (auto sub = (*obj)[std::string_view("item")].as_object())
+            {
+                out.item = ParseSequenceItem(*sub);
+            }
+        }
+        if (obj->contains(std::string_view("from")))
+        {
+            if (auto v = (*obj)[std::string_view("from")].as_int())
+            {
+                out.from = static_cast<std::size_t>(*v);
+            }
+        }
+        if (obj->contains(std::string_view("to")))
+        {
+            if (auto v = (*obj)[std::string_view("to")].as_int())
+            {
+                out.to = static_cast<std::size_t>(*v);
+            }
+        }
+        return true;
+    }
+
+    /// Build the authoring-result JSON. Per das-yyjson-string-safety: string
+    /// members are written with std::make_pair(string_view, copy_string) so the
+    /// data is deep-copied into the document arena (no dangling on return).
+    yyjson::value BuildChangeResultJson(
+        const GR::Contract::AuthoringChangeResult& r,
+        int32_t                                revision)
+    {
+        auto root = Das::Utils::MakeYyjsonObject();
+        auto obj  = root.as_object();
+        (*obj)[std::string_view("ok")]       = r.Ok();
+        (*obj)[std::string_view("revision")] = revision;
+
+        if (!r.Ok())
+        {
+            std::string_view kind_sv = "InvalidOp";
+            switch (r.error_kind)
+            {
+                case GR::Contract::ChangeErrorKind::InvalidOp:      kind_sv = "InvalidOp"; break;
+                case GR::Contract::ChangeErrorKind::NodeNotFound:   kind_sv = "NodeNotFound"; break;
+                case GR::Contract::ChangeErrorKind::DuplicateNodeId:kind_sv = "DuplicateNodeId"; break;
+                case GR::Contract::ChangeErrorKind::EmptyNodeId:    kind_sv = "EmptyNodeId"; break;
+                case GR::Contract::ChangeErrorKind::InvalidEdge:    kind_sv = "InvalidEdge"; break;
+                case GR::Contract::ChangeErrorKind::EdgeNotFound:   kind_sv = "EdgeNotFound"; break;
+                case GR::Contract::ChangeErrorKind::ItemNotFound:   kind_sv = "ItemNotFound"; break;
+                case GR::Contract::ChangeErrorKind::InvalidIndex:   kind_sv = "InvalidIndex"; break;
+                case GR::Contract::ChangeErrorKind::NoChange:       kind_sv = "NoChange"; break;
+                case GR::Contract::ChangeErrorKind::None:           break;
+            }
+            (*obj)[std::string_view("errorKind")] =
+                std::make_pair(kind_sv, yyjson::copy_string);
+            (*obj)[std::string_view("message")] =
+                std::make_pair(std::string_view(r.message), yyjson::copy_string);
+        }
+        return root;
+    }
+} // anonymous namespace
+
+DAS_C_API DasResult CreateGraphAuthoringSession(
+    IDasReadOnlyString*          p_context_json,
+    GraphAuthoringSessionState** pp_out)
+{
+    if (pp_out == nullptr)
+    {
+        return DAS_E_INVALID_POINTER;
+    }
+    *pp_out = nullptr;
+
+    try
+    {
+        auto* s = new GraphAuthoringSessionState();
+        std::string ctx;
+        if (ReadUtf8(p_context_json, ctx))
+        {
+            SeedFromContext(*s, ctx);
+        }
+        *pp_out = s;
+        return DAS_S_OK;
+    }
+    catch (const std::bad_alloc&)
+    {
+        return DAS_E_OUT_OF_MEMORY;
+    }
+}
+
+DAS_C_API void DestroyGraphAuthoringSession(GraphAuthoringSessionState* p)
+{
+    delete p;
+}
+
+DAS_C_API DasResult GraphAuthoringSessionGetDocument(
+    GraphAuthoringSessionState*      p,
+    IDasReadOnlyString*              p_request_json,
+    Das::ExportInterface::IDasJson** pp_out_document_json)
+{
+    std::ignore = p_request_json;
+    if (p == nullptr || pp_out_document_json == nullptr)
+    {
+        return DAS_E_INVALID_POINTER;
+    }
+    *pp_out_document_json = nullptr;
+
+    try
+    {
+        // SerializeDocument builds the contract JSON with copy_string so the
+        // returned value is self-contained; serialise + reparse into IDasJson.
+        auto v   = GR::Contract::SerializeDocument(p->document);
+        auto str = Das::Utils::SerializeYyjsonValue(v);
+        if (!str)
+        {
+            return DAS_E_FAIL;
+        }
+        return ParseDasJsonFromString(str->c_str(), pp_out_document_json);
+    }
+    catch (const std::bad_alloc&)
+    {
+        return DAS_E_OUT_OF_MEMORY;
+    }
+    catch (...)
+    {
+        return DAS_E_FAIL;
+    }
+}
+
+DAS_C_API DasResult GraphAuthoringSessionApplyChange(
+    GraphAuthoringSessionState*      p,
+    IDasReadOnlyString*              p_change_json,
+    Das::ExportInterface::IDasJson** pp_out_result_json)
+{
+    if (p == nullptr || pp_out_result_json == nullptr)
+    {
+        return DAS_E_INVALID_POINTER;
+    }
+    *pp_out_result_json = nullptr;
+
+    try
+    {
+        std::string change_utf8;
+        if (!ReadUtf8(p_change_json, change_utf8))
+        {
+            return DAS_E_INVALID_POINTER;
+        }
+
+        GR::Contract::AuthoringChange change;
+        if (change_utf8.empty())
+        {
+            auto r = WrapValue(
+                BuildChangeResultJson(
+                    {GR::Contract::ChangeErrorKind::InvalidOp, "empty change request"},
+                    p->document.version),
+                pp_out_result_json);
+            return r;
+        }
+
+        auto doc = yyjson::read(change_utf8);
+        if (!ParseAuthoringChange(doc, change))
+        {
+            return WrapValue(
+                BuildChangeResultJson(
+                    {GR::Contract::ChangeErrorKind::InvalidOp, "malformed change request"},
+                    p->document.version),
+                pp_out_result_json);
+        }
+
+        auto          r = GR::Contract::ApplyAuthoringChange(p->document, change);
+        return WrapValue(BuildChangeResultJson(r, p->document.version),
+                         pp_out_result_json);
+    }
+    catch (const std::bad_alloc&)
+    {
+        return DAS_E_OUT_OF_MEMORY;
+    }
+    catch (...)
+    {
+        return DAS_E_FAIL;
+    }
+}
+
+DAS_C_API DasResult GraphAuthoringSessionCompile(
+    GraphAuthoringSessionState*      p,
+    IDasReadOnlyString*              p_request_json,
+    Das::ExportInterface::IDasJson** pp_out_compiled_plan_json)
+{
+    std::ignore = p_request_json;
+    if (p == nullptr || pp_out_compiled_plan_json == nullptr)
+    {
+        return DAS_E_INVALID_POINTER;
+    }
+    *pp_out_compiled_plan_json = nullptr;
+
+    try
+    {
+        // No factory manager bound at the authoring boundary, so manifest port
+        // validation is skipped (acceptable for authoring preview).
+        GR::GraphCompiler compiler;
+        auto              plan = compiler.Compile(p->document);
+        return WrapValue(yyjson::object(plan), pp_out_compiled_plan_json);
+    }
+    catch (const std::bad_alloc&)
+    {
+        return DAS_E_OUT_OF_MEMORY;
+    }
+    catch (...)
+    {
+        return DAS_E_FAIL;
+    }
+}
+
+DAS_C_API DasResult GraphAuthoringSessionUpgradeToGraph(
+    GraphAuthoringSessionState* p)
+{
+    if (p == nullptr)
+    {
+        return DAS_E_INVALID_POINTER;
+    }
+    return GR::Contract::UpgradeToGraph(p->document) ? DAS_S_OK : DAS_E_FAIL;
+}
+

--- a/das/Core/GraphRuntime/src/GraphRuntimeFactory.cpp
+++ b/das/Core/GraphRuntime/src/GraphRuntimeFactory.cpp
@@ -199,6 +199,24 @@ namespace
     // Context seeding
     // -------------------------------------------------------------------
 
+    template <typename Obj>
+    bool ReadStringField(
+        const Obj&           obj,
+        std::string_view     key,
+        std::string&         out)
+    {
+        if (!obj.contains(key))
+        {
+            return false;
+        }
+        if (auto v = obj[key].as_string())
+        {
+            out = std::string(*v);
+            return true;
+        }
+        return false;
+    }
+
     /// Read a GraphDocumentDto field-by-field from a JSON object (robust manual
     /// parse at the boundary; aggregate cast would also work but this avoids
     /// throwing on partial input).
@@ -274,6 +292,188 @@ namespace
         return true;
     }
 
+    // Reverse-map a contract authoring doc (the shape SerializeDocument emits,
+    // and the shape the scheduler persists in `properties`) back onto the
+    // authoritative GraphDocumentDto store. Also accepts a raw formSequence
+    // ({items}) or raw graph ({nodes,edges}) doc for direct callers/tests.
+    void SeedFromDocValue(GraphAuthoringSessionState& s, const yyjson::value& doc)
+    {
+        auto obj = doc.as_object();
+        if (!obj)
+        {
+            return;
+        }
+
+        // Resolve the kind. The contract doc carries {"kind": "formSequence" |
+        // "graph"}; a raw formSequence carries "items"; a raw graph "nodes".
+        std::string kind;
+        ReadStringField(*obj, std::string_view("kind"), kind);
+
+        const bool has_form_seq =
+            obj->contains(std::string_view("formSequence"));
+        const bool has_graph = obj->contains(std::string_view("graph"));
+
+        if (kind == "formSequence" || has_form_seq)
+        {
+            // Contract formSequence doc: formSequence.sequence:[{id,type,settings}].
+            FormSeqDto seq;
+            ReadStringField(*obj, std::string_view("sourceFingerprint"), seq.fingerprint);
+            yyjson::value seq_src = doc;
+            if (has_form_seq)
+            {
+                seq_src = (*obj)[std::string_view("formSequence")];
+            }
+            if (auto seq_obj = seq_src.as_object(); seq_obj && seq_obj->contains(std::string_view("sequence")))
+            {
+                if (auto arr = (*seq_obj)[std::string_view("sequence")].as_array())
+                {
+                    for (const auto& iv : *arr)
+                    {
+                        auto io = iv.as_object();
+                        if (!io)
+                        {
+                            continue;
+                        }
+                        Das::Core::GraphRuntime::Dto::FormSequenceItemDto item;
+                        if (auto v = (*io)[std::string_view("id")].as_string())
+                        {
+                            item.item_id = std::string(*v);
+                        }
+                        std::string type;
+                        ReadStringField(*io, std::string_view("type"), type);
+                        if (!type.empty())
+                        {
+                            item.target.target_kind   = "componentRef";
+                            item.target.component_ref =
+                                Das::Core::GraphRuntime::Dto::ComponentRefDto{
+                                    "componentRef", type, {}};
+                        }
+                        if (io->contains(std::string_view("settings")))
+                        {
+                            item.settings = Das::Utils::CloneYyjsonValue(
+                                (*io)[std::string_view("settings")]);
+                        }
+                        seq.items.push_back(std::move(item));
+                    }
+                }
+            }
+            s.document = GR::FormSequenceProjector::Project(seq);
+            s.document.tags.emplace_back(GR::Contract::kLinearTag);
+            return;
+        }
+
+        if (kind == "graph" || has_graph)
+        {
+            yyjson::value graph_src = doc;
+            if (has_graph)
+            {
+                graph_src = (*obj)[std::string_view("graph")];
+            }
+            if (auto gobj = graph_src.as_object())
+            {
+                ReadStringField(*obj, std::string_view("sourceFingerprint"), s.document.fingerprint);
+                if (gobj->contains(std::string_view("nodes")))
+                {
+                    if (auto arr = (*gobj)[std::string_view("nodes")].as_array())
+                    {
+                        for (const auto& nv : *arr)
+                        {
+                            auto no = nv.as_object();
+                            if (!no)
+                            {
+                                continue;
+                            }
+                            Das::Core::GraphRuntime::Dto::GraphNodeDto node;
+                            if (auto v = (*no)[std::string_view("id")].as_string())
+                            {
+                                node.node_id = std::string(*v);
+                            }
+                            std::string guid;
+                            ReadStringField(*no, std::string_view("componentGuid"), guid);
+                            if (!guid.empty())
+                            {
+                                node.target.target_kind   = "componentRef";
+                                node.target.component_ref =
+                                    Das::Core::GraphRuntime::Dto::ComponentRefDto{
+                                        "componentRef", guid, {}};
+                            }
+                            if (no->contains(std::string_view("settings")))
+                            {
+                                node.settings = Das::Utils::CloneYyjsonValue(
+                                    (*no)[std::string_view("settings")]);
+                            }
+                            s.document.nodes.push_back(std::move(node));
+                        }
+                    }
+                }
+                if (gobj->contains(std::string_view("connections")))
+                {
+                    if (auto arr = (*gobj)[std::string_view("connections")].as_array())
+                    {
+                        for (const auto& cv : *arr)
+                        {
+                            auto co = cv.as_object();
+                            if (!co)
+                            {
+                                continue;
+                            }
+                            Das::Core::GraphRuntime::Dto::GraphEdgeDto edge;
+                            std::string                               from_n, from_p, to_n, to_p;
+                            ReadStringField(*co, std::string_view("fromNodeId"), from_n);
+                            ReadStringField(*co, std::string_view("fromPortId"), from_p);
+                            ReadStringField(*co, std::string_view("toNodeId"), to_n);
+                            ReadStringField(*co, std::string_view("toPortId"), to_p);
+                            edge.edge_id        = "edge::" + from_n + "::" + to_n;
+                            edge.source_node_id = from_n;
+                            edge.source_port_id = from_p;
+                            edge.target_node_id = to_n;
+                            edge.target_port_id = to_p;
+                            edge.edge_type      = "data";
+                            s.document.edges.push_back(std::move(edge));
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
+        // Raw formSequence ({items}) / raw graph ({nodes}) fallback.
+        if (obj->contains(std::string_view("items")))
+        {
+            FormSeqDto seq;
+            ReadStringField(*obj, std::string_view("documentId"), seq.document_id);
+            if (obj->contains(std::string_view("version")))
+            {
+                if (auto v = (*obj)[std::string_view("version")].as_int())
+                {
+                    seq.version = static_cast<int32_t>(*v);
+                }
+            }
+            ReadStringField(*obj, std::string_view("fingerprint"), seq.fingerprint);
+            if (auto items = (*obj)[std::string_view("items")].as_array())
+            {
+                for (const auto& iv : *items)
+                {
+                    try
+                    {
+                        seq.items.push_back(
+                            GR::Dto::Detail::CastDtoObject<
+                                Das::Core::GraphRuntime::Dto::FormSequenceItemDto>(iv));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
+            s.document = GR::FormSequenceProjector::Project(seq);
+            s.document.tags.emplace_back(GR::Contract::kLinearTag);
+        }
+        else if (obj->contains(std::string_view("nodes")))
+        {
+            ParseGraphDoc(*obj, s.document);
+        }
+    }
+
     void SeedFromContext(GraphAuthoringSessionState& s, std::string_view json)
     {
         if (json.empty())
@@ -294,70 +494,29 @@ namespace
         {
             return;
         }
-        if (obj->contains(std::string_view("items")))
+
+        // Real scheduler context shape: {taskId, properties, revision, authoring}.
+        // The live store round-trips through `properties` as a contract authoring
+        // doc (what SerializeDocument emits and ApplyChange returns as
+        // acceptedProperties). Prefer `properties`; fall back to a raw/contract
+        // doc at top level for direct callers and tests.
+        if (obj->contains(std::string_view("properties")))
         {
-            // formSequence context → project to a linear GraphDocumentDto.
-            FormSeqDto seq;
-            if (auto v = (*obj)[std::string_view("documentId")].as_string())
-            {
-                seq.document_id = std::string(*v);
-            }
-            if (auto v = (*obj)[std::string_view("version")].as_int())
-            {
-                seq.version = static_cast<int32_t>(*v);
-            }
-            if (auto v = (*obj)[std::string_view("fingerprint")].as_string())
-            {
-                seq.fingerprint = std::string(*v);
-            }
-            auto items = (*obj)[std::string_view("items")].as_array();
-            if (items)
-            {
-                for (const auto& iv : *items)
-                {
-                    try
-                    {
-                        seq.items.push_back(
-                            GR::Dto::Detail::CastDtoObject<
-                                Das::Core::GraphRuntime::Dto::FormSequenceItemDto>(iv));
-                    }
-                    catch (...)
-                    {
-                    }
-                }
-            }
-            s.document = GR::FormSequenceProjector::Project(seq);
-            s.document.tags.emplace_back(GR::Contract::kLinearTag);
+            SeedFromDocValue(s, (*obj)[std::string_view("properties")]);
+            return;
         }
-        else if (obj->contains(std::string_view("nodes")))
+        if (obj->contains(std::string_view("kind"))
+            || obj->contains(std::string_view("items"))
+            || obj->contains(std::string_view("nodes")))
         {
-            // graph context → parse directly.
-            ParseGraphDoc(*obj, s.document);
+            SeedFromDocValue(s, root);
         }
-        // else: leave empty (graph-mode) store.
+        // else: empty (graph-mode) store.
     }
 
     // -------------------------------------------------------------------
     // Contract change parsing
     // -------------------------------------------------------------------
-
-    template <typename Obj>
-    bool ReadStringField(
-        const Obj&           obj,
-        std::string_view     key,
-        std::string&         out)
-    {
-        if (!obj.contains(key))
-        {
-            return false;
-        }
-        if (auto v = obj[key].as_string())
-        {
-            out = std::string(*v);
-            return true;
-        }
-        return false;
-    }
 
     template <typename Obj>
     std::optional<GR::Contract::GraphNode>
@@ -473,16 +632,37 @@ namespace
     /// Build the authoring-result JSON. Per das-yyjson-string-safety: string
     /// members are written with std::make_pair(string_view, copy_string) so the
     /// data is deep-copied into the document arena (no dangling on return).
+    /// Build the apply-result JSON. On success it conforms to the scheduler's
+    /// authoring provider contract: {acceptedProperties, document,
+    /// sourceFingerprint} (+ ok/revision for direct callers). The store round-
+    /// trips through acceptedProperties as the contract authoring doc that
+    /// SerializeDocument emits. Per das-yyjson-string-safety: assigning a
+    /// yyjson::value deep-copies the subtree (safe, unlike a string lvalue);
+    /// string scalars use std::make_pair(string_view, copy_string).
     yyjson::value BuildChangeResultJson(
         const GR::Contract::AuthoringChangeResult& r,
-        int32_t                                revision)
+        int32_t                                    revision,
+        const GraphDocDto&                         document)
     {
         auto root = Das::Utils::MakeYyjsonObject();
         auto obj  = root.as_object();
         (*obj)[std::string_view("ok")]       = r.Ok();
         (*obj)[std::string_view("revision")] = revision;
 
-        if (!r.Ok())
+        if (r.Ok())
+        {
+            // The contract authoring doc is the canonical persisted state
+            // (acceptedProperties) and the refreshed document the scheduler
+            // returns to the client.
+            (*obj)[std::string_view("acceptedProperties")] =
+                GR::Contract::SerializeDocument(document);
+            (*obj)[std::string_view("document")] =
+                GR::Contract::SerializeDocument(document);
+            (*obj)[std::string_view("sourceFingerprint")] =
+                std::make_pair(std::string_view(document.fingerprint),
+                               yyjson::copy_string);
+        }
+        else
         {
             std::string_view kind_sv = "InvalidOp";
             switch (r.error_kind)
@@ -598,7 +778,8 @@ DAS_C_API DasResult GraphAuthoringSessionApplyChange(
             auto r = WrapValue(
                 BuildChangeResultJson(
                     {GR::Contract::ChangeErrorKind::InvalidOp, "empty change request"},
-                    p->document.version),
+                    p->document.version,
+                    p->document),
                 pp_out_result_json);
             return r;
         }
@@ -609,12 +790,13 @@ DAS_C_API DasResult GraphAuthoringSessionApplyChange(
             return WrapValue(
                 BuildChangeResultJson(
                     {GR::Contract::ChangeErrorKind::InvalidOp, "malformed change request"},
-                    p->document.version),
+                    p->document.version,
+                    p->document),
                 pp_out_result_json);
         }
 
         auto          r = GR::Contract::ApplyAuthoringChange(p->document, change);
-        return WrapValue(BuildChangeResultJson(r, p->document.version),
+        return WrapValue(BuildChangeResultJson(r, p->document.version, p->document),
                          pp_out_result_json);
     }
     catch (const std::bad_alloc&)

--- a/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
+++ b/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
@@ -1,0 +1,221 @@
+#include <das/Core/GraphRuntime/AuthoringDocContract.h>
+#include <das/Core/GraphRuntime/FormSequenceProjector.h>
+#include <das/Core/GraphRuntime/GraphDocument.h>
+#include <das/Utils/DasJsonCore.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+namespace
+{
+    using namespace Das::Core::GraphRuntime;
+    using namespace Das::Core::GraphRuntime::Contract;
+    using namespace Das::Core::GraphRuntime::Dto;
+
+    // -----------------------------------------------------------------------
+    // Builders
+    // -----------------------------------------------------------------------
+
+    yyjson::value MakeSettings(double v)
+    {
+        auto payload = Das::Utils::MakeYyjsonObject();
+        auto obj     = *payload.as_object();
+        obj[std::string_view("threshold")] = v;
+        return payload;
+    }
+
+    ComponentRefDto MakeCompRef(std::string_view guid)
+    {
+        return ComponentRefDto{
+            std::string("componentRef"),
+            std::string(guid),
+            std::string("{plug-guid}")};
+    }
+
+    GraphNodeDto MakeNode(
+        std::string_view id,
+        std::string_view guid,
+        double           settings_val)
+    {
+        GraphNodeDto node;
+        node.node_id = std::string(id);
+        node.target.target_kind   = "componentRef";
+        node.target.component_ref = MakeCompRef(guid);
+        node.settings             = MakeSettings(settings_val);
+        return node;
+    }
+
+    GraphEdgeDto MakeSignalEdge(
+        std::string_view id,
+        std::string_view from,
+        std::string_view to)
+    {
+        GraphEdgeDto edge;
+        edge.edge_id        = std::string(id);
+        edge.source_node_id = std::string(from);
+        edge.source_port_id = std::string(FormSequenceProjector::SignalOutPort);
+        edge.target_node_id = std::string(to);
+        edge.target_port_id = std::string(FormSequenceProjector::SignalInPort);
+        edge.edge_type      = "signal";
+        return edge;
+    }
+
+    /// Serialize the authoritative store directly into contract JSON.
+    std::string ToJson(const Dto::GraphDocumentDto& doc)
+    {
+        auto v   = Contract::SerializeDocument(doc);
+        auto str = Das::Utils::SerializeYyjsonValue(v);
+        return str.value_or(std::string{});
+    }
+
+    // -----------------------------------------------------------------------
+    // ToAuthoringDocument — graph mode (no linear tag)
+    // -----------------------------------------------------------------------
+
+    TEST(AuthoringDocContractTest, GraphMode_ThinMapsNodesAndDropsPrivateFields)
+    {
+        GraphDocumentDto doc;
+        doc.version     = 7;
+        doc.fingerprint = "fp";
+        doc.nodes.push_back(MakeNode("n1", "{g1}", 0.1));
+        doc.nodes.push_back(MakeNode("n2", "{g2}", 0.2));
+        doc.edges.push_back(MakeSignalEdge("e1", "n1", "n2"));
+
+        auto out = ToAuthoringDocument(doc);
+        ASSERT_EQ(out.kind, Kind::Graph);
+        ASSERT_TRUE(out.graph.has_value());
+        ASSERT_FALSE(out.form_sequence.has_value());
+
+        const auto& view = *out.graph;
+        ASSERT_EQ(view.nodes.size(), 2u);
+        EXPECT_EQ(view.nodes[0].id, "n1");
+        EXPECT_EQ(view.nodes[0].component_guid, "{g1}");
+        ASSERT_EQ(view.connections.size(), 1u);
+        EXPECT_EQ(view.connections[0].from_node_id, "n1");
+        EXPECT_EQ(view.connections[0].to_node_id, "n2");
+    }
+
+    TEST(AuthoringDocContractTest, GraphMode_SerializeHasNoEdgeTypeOrEdgeId)
+    {
+        GraphDocumentDto doc;
+        doc.nodes.push_back(MakeNode("n1", "{g1}", 0.0));
+        doc.nodes.push_back(MakeNode("n2", "{g2}", 0.0));
+        // A non-signal (data) edge to prove edge_type is stripped regardless.
+        GraphEdgeDto edge =
+            MakeSignalEdge("private-edge", "n1", "n2");
+        edge.edge_type = "data";
+        doc.edges.push_back(edge);
+
+        auto json = ToJson(doc);
+        EXPECT_EQ(json.find("edgeType"), std::string::npos);
+        EXPECT_EQ(json.find("edgeId"), std::string::npos);
+        EXPECT_EQ(json.find("dynamicPorts"), std::string::npos);
+        EXPECT_NE(json.find("\"graph\""), std::string::npos);
+        EXPECT_NE(json.find("\"connections\""), std::string::npos);
+    }
+
+    // -----------------------------------------------------------------------
+    // ToAuthoringDocument — formSequence mode (linear tag)
+    // -----------------------------------------------------------------------
+
+    TEST(AuthoringDocContractTest, FormSequenceMode_ReverseProjectsLinearChain)
+    {
+        // Build via the projector so the structure matches production.
+        FormSequenceDto seq;
+        seq.version     = 3;
+        seq.fingerprint = "seq-fp";
+        seq.items.push_back({.item_id = "a",
+                             .target  = {.target_kind = "componentRef",
+                                        .component_ref = MakeCompRef("{ga}")},
+                             .settings = MakeSettings(1.0)});
+        seq.items.push_back({.item_id = "b",
+                             .target  = {.target_kind = "componentRef",
+                                        .component_ref = MakeCompRef("{gb}")},
+                             .settings = MakeSettings(2.0)});
+        seq.items.push_back({.item_id = "c",
+                             .target  = {.target_kind = "componentRef",
+                                        .component_ref = MakeCompRef("{gc}")},
+                             .settings = MakeSettings(3.0)});
+
+        auto doc = FormSequenceProjector::Project(seq);
+        doc.tags.emplace_back(kLinearTag); // mark linear state
+
+        auto out = ToAuthoringDocument(doc);
+        ASSERT_EQ(out.kind, Kind::FormSequence);
+        ASSERT_TRUE(out.form_sequence.has_value());
+        ASSERT_FALSE(out.graph.has_value());
+
+        const auto& items = out.form_sequence->sequence;
+        ASSERT_EQ(items.size(), 3u);
+        EXPECT_EQ(items[0].id, "a");
+        EXPECT_EQ(items[0].type, "{ga}");
+        EXPECT_EQ(items[1].id, "b");
+        EXPECT_EQ(items[2].id, "c");
+    }
+
+    TEST(AuthoringDocContractTest, FormSequenceMode_SerializeShape)
+    {
+        GraphDocumentDto doc;
+        doc.version = 1;
+        doc.nodes.push_back(MakeNode("x", "{gx}", 9.0));
+        doc.tags.emplace_back(kLinearTag);
+
+        auto json = ToJson(doc);
+        EXPECT_NE(json.find("\"kind\":\"formSequence\""), std::string::npos);
+        EXPECT_NE(json.find("\"formSequence\""), std::string::npos);
+        EXPECT_NE(json.find("\"sequence\""), std::string::npos);
+        // Private fields must not leak even in formSequence mode.
+        EXPECT_EQ(json.find("edgeType"), std::string::npos);
+    }
+
+    // -----------------------------------------------------------------------
+    // Upgrade / downgrade — lossless on the store
+    // -----------------------------------------------------------------------
+
+    TEST(AuthoringDocContractTest, UpgradeToGraph_RemovesTagAndIsLossless)
+    {
+        FormSequenceDto seq;
+        seq.items.push_back({.item_id = "a",
+                             .target  = {.target_kind = "componentRef"}});
+        seq.items.push_back({.item_id = "b",
+                             .target  = {.target_kind = "componentRef"}});
+        auto doc = FormSequenceProjector::Project(seq);
+        doc.tags.emplace_back(kLinearTag);
+        const auto  nodes_before = doc.nodes.size();
+        const auto  edges_before = doc.edges.size();
+
+        ASSERT_TRUE(UpgradeToGraph(doc));
+        EXPECT_FALSE(IsLinear(doc));
+        // Store untouched apart from the tag.
+        EXPECT_EQ(doc.nodes.size(), nodes_before);
+        EXPECT_EQ(doc.edges.size(), edges_before);
+
+        // After upgrade, projection is graph mode.
+        EXPECT_EQ(ToAuthoringDocument(doc).kind, Kind::Graph);
+
+        // Reversible: downgrade restores the formSequence view.
+        ASSERT_TRUE(DowngradeToFormSequence(doc));
+        EXPECT_TRUE(IsLinear(doc));
+        EXPECT_EQ(ToAuthoringDocument(doc).kind, Kind::FormSequence);
+    }
+
+    TEST(AuthoringDocContractTest, Upgrade_IsIdempotentWhenNotLinear)
+    {
+        GraphDocumentDto doc; // no tag
+        EXPECT_FALSE(UpgradeToGraph(doc));
+        EXPECT_FALSE(DowngradeToFormSequence(doc) == false); // first add succeeds
+        EXPECT_FALSE(DowngradeToFormSequence(doc));          // already linear
+    }
+
+    TEST(AuthoringDocContractTest, IsLinear_RespectsOnlyCanonicalTag)
+    {
+        GraphDocumentDto doc;
+        EXPECT_FALSE(IsLinear(doc));
+        doc.tags.emplace_back("fromsequence"); // legacy/other tag — not linear
+        EXPECT_FALSE(IsLinear(doc));
+        doc.tags.emplace_back(kLinearTag);
+        EXPECT_TRUE(IsLinear(doc));
+    }
+} // namespace
+

--- a/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
+++ b/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
@@ -189,9 +189,54 @@ namespace
         EXPECT_EQ(json.find("edgeType"), std::string::npos);
     }
 
+    // Comprehensive zero-leak guard: the contract output must NEVER carry any
+    // runtime-private field, regardless of mode or edge type. Covers edgeType,
+    // edgeId, dynamicPorts, and the signal/data edge-type tokens (which only
+    // exist on the internal GraphEdgeDto, never on the contract GraphConnection).
+    TEST(AuthoringDocContractTest, BothModes_NeverLeakRuntimePrivateFields)
+    {
+        // graph mode: a node with dynamic_ports + a data edge + a signal edge.
+        GraphDocumentDto g;
+        auto& n1 = g.nodes.emplace_back(MakeNode("n1", "{g1}", 0.0));
+        n1.dynamic_ports.push_back({.port_id = "dyn", .port_type = "data"});
+        g.nodes.push_back(MakeNode("n2", "{g2}", 0.0));
+        GraphEdgeDto data_edge = MakeSignalEdge("e-data", "n1", "n2");
+        data_edge.edge_type    = "data";
+        g.edges.push_back(data_edge);
+        GraphEdgeDto sig = MakeSignalEdge("e-sig", "n1", "n2");
+        g.edges.push_back(sig);
+
+        const auto graph_json = ToJson(g);
+        EXPECT_EQ(graph_json.find("edgeType"), std::string::npos);
+        EXPECT_EQ(graph_json.find("edgeId"), std::string::npos);
+        EXPECT_EQ(graph_json.find("dynamicPorts"), std::string::npos);
+        EXPECT_EQ(graph_json.find("\"signal\""), std::string::npos);
+        EXPECT_EQ(graph_json.find("\"data\""), std::string::npos);
+
+        // formSequence mode: project a sequence (signal edges auto-generated) +
+        // ensure the same fields are absent in the projected view.
+        FormSequenceDto seq;
+        seq.items.push_back({.item_id = "a",
+                             .target  = {.target_kind = "componentRef",
+                                         .component_ref = MakeCompRef("{ga}")},
+                             .settings = MakeSettings(1.0)});
+        seq.items.push_back({.item_id = "b",
+                             .target  = {.target_kind = "componentRef",
+                                         .component_ref = MakeCompRef("{gb}")},
+                             .settings = MakeSettings(2.0)});
+        auto fdoc = FormSequenceProjector::Project(seq);
+        fdoc.tags.emplace_back(kLinearTag);
+        const auto fs_json = ToJson(fdoc);
+        EXPECT_EQ(fs_json.find("edgeType"), std::string::npos);
+        EXPECT_EQ(fs_json.find("edgeId"), std::string::npos);
+        EXPECT_EQ(fs_json.find("dynamicPorts"), std::string::npos);
+        EXPECT_EQ(fs_json.find("\"signal\""), std::string::npos);
+    }
+
     // -----------------------------------------------------------------------
-    // Upgrade / downgrade — lossless on the store
+    // Upgrade — one-way, lossless on the store
     // -----------------------------------------------------------------------
+
 
     TEST(AuthoringDocContractTest, UpgradeToGraph_RemovesTagAndIsLossless)
     {
@@ -207,26 +252,26 @@ namespace
 
         ASSERT_TRUE(UpgradeToGraph(doc));
         EXPECT_FALSE(IsLinear(doc));
-        // Store untouched apart from the tag.
+        // Store untouched apart from the tag → lossless.
         EXPECT_EQ(doc.nodes.size(), nodes_before);
         EXPECT_EQ(doc.edges.size(), edges_before);
 
         // After upgrade, projection is graph mode.
         EXPECT_EQ(ToAuthoringDocument(doc).kind, Kind::Graph);
 
-        // Reversible: downgrade restores the formSequence view.
-        ASSERT_TRUE(DowngradeToFormSequence(doc));
-        EXPECT_TRUE(IsLinear(doc));
-        EXPECT_EQ(ToAuthoringDocument(doc).kind, Kind::FormSequence);
+        // One-way: re-applying UpgradeToGraph on an already-graph doc is a no-op
+        // (returns false), and there is intentionally no downgrade path.
+        EXPECT_FALSE(UpgradeToGraph(doc));
+        EXPECT_EQ(ToAuthoringDocument(doc).kind, Kind::Graph);
     }
 
-    TEST(AuthoringDocContractTest, Upgrade_IsIdempotentWhenNotLinear)
+    TEST(AuthoringDocContractTest, Upgrade_IsNoOpWhenNotLinear)
     {
-        GraphDocumentDto doc; // no tag
-        EXPECT_FALSE(UpgradeToGraph(doc));
-        EXPECT_FALSE(DowngradeToFormSequence(doc) == false); // first add succeeds
-        EXPECT_FALSE(DowngradeToFormSequence(doc));          // already linear
+        GraphDocumentDto doc; // no tag → already graph mode
+        EXPECT_FALSE(UpgradeToGraph(doc)); // nothing to remove
+        EXPECT_FALSE(IsLinear(doc));
     }
+
 
     TEST(AuthoringDocContractTest, IsLinear_RespectsOnlyCanonicalTag)
     {

--- a/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
+++ b/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
@@ -217,5 +217,182 @@ namespace
         doc.tags.emplace_back(kLinearTag);
         EXPECT_TRUE(IsLinear(doc));
     }
+
+    // -----------------------------------------------------------------------
+    // ApplyAuthoringChange — graph mode (delegates to GraphAuthoring)
+    // -----------------------------------------------------------------------
+
+    TEST(AuthoringDocContractTest, GraphChange_AddNodeThenConnectPorts)
+    {
+        GraphDocumentDto doc; // graph mode (no tag)
+        doc.version = 0;
+
+        AuthoringChange add;
+        add.op   = "addNode";
+        add.node = GraphNode{"n1", "{g1}", MakeSettings(1.0)};
+        ASSERT_TRUE(ApplyAuthoringChange(doc, add).Ok());
+        ASSERT_EQ(doc.nodes.size(), 1u);
+        EXPECT_EQ(doc.version, 1);
+
+        AuthoringChange add2;
+        add2.op   = "addNode";
+        add2.node = GraphNode{"n2", "{g2}", MakeSettings(2.0)};
+        ASSERT_TRUE(ApplyAuthoringChange(doc, add2).Ok());
+
+        AuthoringChange conn;
+        conn.op         = "connectPorts";
+        conn.connection = GraphConnection{"n1", "out", "n2", "in"};
+        ASSERT_TRUE(ApplyAuthoringChange(doc, conn).Ok());
+        ASSERT_EQ(doc.edges.size(), 1u);
+        EXPECT_EQ(doc.edges[0].source_node_id, "n1");
+        EXPECT_EQ(doc.edges[0].edge_type, "data"); // graph-mode edges are data
+
+        // The public projection still hides edge_type / edge_id.
+        auto json = ToJson(doc);
+        EXPECT_EQ(json.find("edgeType"), std::string::npos);
+        EXPECT_EQ(json.find("edgeId"), std::string::npos);
+    }
+
+    TEST(AuthoringDocContractTest, GraphChange_RemoveNodeCascadesEdges)
+    {
+        GraphDocumentDto doc;
+        doc.nodes.push_back(MakeNode("n1", "{g1}", 0.0));
+        doc.nodes.push_back(MakeNode("n2", "{g2}", 0.0));
+        GraphEdgeDto e;
+        e.edge_id = "e1"; e.source_node_id = "n1"; e.source_port_id = "o";
+        e.target_node_id = "n2"; e.target_port_id = "i"; e.edge_type = "data";
+        doc.edges.push_back(e);
+
+        AuthoringChange rm;
+        rm.op = "removeNode";
+        rm.node_id = "n1";
+        ASSERT_TRUE(ApplyAuthoringChange(doc, rm).Ok());
+        ASSERT_EQ(doc.nodes.size(), 1u);
+        EXPECT_EQ(doc.nodes[0].node_id, "n2");
+        EXPECT_TRUE(doc.edges.empty()); // cascade
+    }
+
+    TEST(AuthoringDocContractTest, GraphChange_DisconnectByEndpoints)
+    {
+        GraphDocumentDto doc;
+        doc.nodes.push_back(MakeNode("n1", "{g1}", 0.0));
+        doc.nodes.push_back(MakeNode("n2", "{g2}", 0.0));
+        GraphEdgeDto e;
+        e.edge_id = "private"; e.source_node_id = "n1"; e.source_port_id = "o";
+        e.target_node_id = "n2"; e.target_port_id = "i"; e.edge_type = "data";
+        doc.edges.push_back(e);
+
+        AuthoringChange disc;
+        disc.op         = "disconnectPorts";
+        disc.connection = GraphConnection{"n1", "o", "n2", "i"};
+        ASSERT_TRUE(ApplyAuthoringChange(doc, disc).Ok());
+        EXPECT_TRUE(doc.edges.empty());
+    }
+
+    TEST(AuthoringDocContractTest, GraphChange_DuplicateNodeIsRejected)
+    {
+        GraphDocumentDto doc;
+        doc.nodes.push_back(MakeNode("n1", "{g1}", 0.0));
+        const auto before = doc.nodes.size();
+
+        AuthoringChange add;
+        add.op = "addNode";
+        add.node = GraphNode{"n1", "{g1}", MakeSettings(0.0)};
+        auto r = ApplyAuthoringChange(doc, add);
+        ASSERT_FALSE(r.Ok());
+        EXPECT_EQ(r.error_kind, ChangeErrorKind::DuplicateNodeId);
+        EXPECT_EQ(doc.nodes.size(), before); // unchanged
+    }
+
+    // -----------------------------------------------------------------------
+    // ApplyAuthoringChange — linear mode (reuses FormSequenceProjector)
+    // -----------------------------------------------------------------------
+
+    TEST(AuthoringDocContractTest, LinearChange_AddItemAppendsToChain)
+    {
+        // Seed a 2-item linear store via the projector + tag.
+        FormSequenceDto seq;
+        seq.items.push_back({.item_id = "a", .target = {.target_kind = "componentRef",
+                              .component_ref = MakeCompRef("{ga}")}, .settings = MakeSettings(1.0)});
+        seq.items.push_back({.item_id = "b", .target = {.target_kind = "componentRef",
+                              .component_ref = MakeCompRef("{gb}")}, .settings = MakeSettings(2.0)});
+        auto doc = FormSequenceProjector::Project(seq);
+        doc.tags.emplace_back(kLinearTag);
+        ASSERT_EQ(doc.edges.size(), 1u); // a->b signal
+
+        AuthoringChange add;
+        add.op   = "addSequenceItem";
+        add.item = SequenceItem{"c", "{gc}", MakeSettings(3.0)};
+        ASSERT_TRUE(ApplyAuthoringChange(doc, add).Ok());
+
+        // Chain extended: a->b->c (two signal edges), still linear.
+        ASSERT_EQ(doc.nodes.size(), 3u);
+        ASSERT_EQ(doc.edges.size(), 2u);
+        EXPECT_TRUE(IsLinear(doc));
+        EXPECT_EQ(doc.edges[0].edge_type, "signal");
+    }
+
+    TEST(AuthoringDocContractTest, LinearChange_RemoveItemReconnectsChain)
+    {
+        FormSequenceDto seq;
+        seq.items.push_back({.item_id = "a", .target = {.target_kind = "componentRef",
+                              .component_ref = MakeCompRef("{ga}")}});
+        seq.items.push_back({.item_id = "b", .target = {.target_kind = "componentRef",
+                              .component_ref = MakeCompRef("{gb}")}});
+        seq.items.push_back({.item_id = "c", .target = {.target_kind = "componentRef",
+                              .component_ref = MakeCompRef("{gc}")}});
+        auto doc = FormSequenceProjector::Project(seq);
+        doc.tags.emplace_back(kLinearTag);
+
+        AuthoringChange rm;
+        rm.op = "removeSequenceItem";
+        rm.node_id = "b";
+        ASSERT_TRUE(ApplyAuthoringChange(doc, rm).Ok());
+
+        // b gone; chain a->c reconnected (1 signal edge).
+        ASSERT_EQ(doc.nodes.size(), 2u);
+        ASSERT_EQ(doc.edges.size(), 1u);
+        EXPECT_EQ(doc.edges[0].source_node_id, "a");
+        EXPECT_EQ(doc.edges[0].target_node_id, "c");
+    }
+
+    TEST(AuthoringDocContractTest, LinearChange_MoveItemReordersChain)
+    {
+        FormSequenceDto seq;
+        for (char c : {'a', 'b', 'c'})
+        {
+            seq.items.push_back({.item_id = std::string(1, c),
+                                 .target = {.target_kind = "componentRef",
+                                            .component_ref = MakeCompRef("{g}")}});
+        }
+        auto doc = FormSequenceProjector::Project(seq);
+        doc.tags.emplace_back(kLinearTag);
+
+        AuthoringChange mv;
+        mv.op   = "moveSequenceItem";
+        mv.from = 0;
+        mv.to   = 2; // a moves to the end → b->c->a
+        ASSERT_TRUE(ApplyAuthoringChange(doc, mv).Ok());
+
+        // New head is b.
+        auto items = ToAuthoringDocument(doc).form_sequence->sequence;
+        ASSERT_EQ(items.size(), 3u);
+        EXPECT_EQ(items[0].id, "b");
+        EXPECT_EQ(items[1].id, "c");
+        EXPECT_EQ(items[2].id, "a");
+    }
+
+    TEST(AuthoringDocContractTest, LinearChange_RejectsGraphOp)
+    {
+        GraphDocumentDto doc;
+        doc.tags.emplace_back(kLinearTag);
+
+        AuthoringChange bad;
+        bad.op = "addNode";
+        bad.node = GraphNode{"x", "{g}", MakeSettings(0.0)};
+        auto r = ApplyAuthoringChange(doc, bad);
+        EXPECT_FALSE(r.Ok());
+        EXPECT_EQ(r.error_kind, ChangeErrorKind::InvalidOp);
+    }
 } // namespace
 

--- a/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
+++ b/das/Core/GraphRuntime/test/AuthoringDocContractTest.cpp
@@ -115,6 +115,26 @@ namespace
         EXPECT_NE(json.find("\"connections\""), std::string::npos);
     }
 
+    // copy_string must deep-copy strings nested INSIDE yyjson::value settings
+    // subtrees too, not just top-level scalar members — otherwise the returned
+    // value dangles once the store is gone (das-yyjson-string-safety skill).
+    TEST(AuthoringDocContractTest, GraphMode_CopyStringDeepCopiesNestedStringSettings)
+    {
+        GraphDocumentDto doc;
+        // settings carries a string payload that would dangle if not copied.
+        auto payload = Das::Utils::MakeYyjsonObject();
+        auto sobj    = *payload.as_object();
+        sobj[std::string_view("name")]      = std::string("deep-string-payload");
+        sobj[std::string_view("threshold")] = 0.5;
+        doc.nodes.push_back(MakeNode("n1", "{g1}", 0.0));
+        doc.nodes.back().settings = payload;
+
+        auto json = ToJson(doc);
+        EXPECT_NE(json.find("deep-string-payload"), std::string::npos);
+        // Sanity: the nested object survived the cross-boundary return intact.
+        EXPECT_NE(json.find("\"threshold\":0.5"), std::string::npos);
+    }
+
     // -----------------------------------------------------------------------
     // ToAuthoringDocument — formSequence mode (linear tag)
     // -----------------------------------------------------------------------

--- a/das/Core/GraphRuntime/test/GraphAuthoringSessionTest.cpp
+++ b/das/Core/GraphRuntime/test/GraphAuthoringSessionTest.cpp
@@ -216,7 +216,7 @@ namespace
         EXPECT_NE(plan.find("executionOrder"), std::string::npos);
     }
 
-    TEST(GraphAuthoringSessionTest, E2E_UpgradeIsLosslessAndDowngradeTriggersLint)
+    TEST(GraphAuthoringSessionTest, E2E_UpgradeIsLossless)
     {
         // Seed linear, capture nodes, upgrade (lossless), downgrade, and check
         // the linearity lint fires on the resulting linear store.

--- a/das/Core/GraphRuntime/test/GraphAuthoringSessionTest.cpp
+++ b/das/Core/GraphRuntime/test/GraphAuthoringSessionTest.cpp
@@ -153,4 +153,86 @@ namespace
         EXPECT_NE(doc.find("\"id\":\"a\""), std::string::npos);
         EXPECT_NE(doc.find("\"id\":\"b\""), std::string::npos);
     }
+
+    // -----------------------------------------------------------------------
+    // E2E: store round-trips through the scheduler contract
+    // (context.properties <-> ApplyChange.acceptedProperties)
+    // -----------------------------------------------------------------------
+
+    /// Extract the acceptedProperties blob from an ApplyChange result.
+    std::string ExtractAcceptedProperties(Das::ExportInterface::IDasJson* r)
+    {
+        auto full = JsonToUtf8(r);
+        auto obj  = yyjson::read(full).as_object();
+        if (!obj || !obj->contains(std::string_view("acceptedProperties")))
+        {
+            return {};
+        }
+        auto v = Das::Utils::SerializeYyjsonValue(
+            (*obj)[std::string_view("acceptedProperties")]);
+        return v.value_or(std::string{});
+    }
+
+    TEST(GraphAuthoringSessionTest, E2E_StoreRoundTripsThroughProperties)
+    {
+        // Start empty (graph mode), add a node, take the acceptedProperties the
+        // scheduler would persist, and re-seed a fresh session from it — the
+        // node must survive the round-trip.
+        SessionHandle s1{""};
+        ASSERT_TRUE(Compact(JsonToUtf8(ApplyChange(s1.p,
+            R"({"op":"addNode","node":{"id":"n1","componentGuid":"{g1}","settings":{}}})").Get()))
+            .find("\"ok\":true") != std::string::npos);
+
+        const auto persisted = ExtractAcceptedProperties(
+            ApplyChange(s1.p,
+                R"({"op":"addNode","node":{"id":"n2","componentGuid":"{g2}","settings":{}}})")
+                .Get());
+        ASSERT_FALSE(persisted.empty());
+
+        // Re-seed from the persisted contract doc (wrapped as scheduler context).
+        const std::string ctx =
+            std::string(R"({"properties":)") + persisted + "}";
+        SessionHandle s2{ctx};
+        const auto doc = Compact(JsonToUtf8(GetDocument(s2.p).Get()));
+        EXPECT_NE(doc.find("\"id\":\"n1\""), std::string::npos);
+        EXPECT_NE(doc.find("\"id\":\"n2\""), std::string::npos);
+        EXPECT_NE(doc.find("\"kind\":\"graph\""), std::string::npos);
+    }
+
+    TEST(GraphAuthoringSessionTest, E2E_CompileProducesExecutablePlan)
+    {
+        // Seed a graph store, Compile, and confirm the plan is well-formed
+        // (object with the compiled-plan shape; execution itself is exercised
+        // by DasGraphTaskTest / GraphRuntimeTest).
+        SessionHandle s{""};
+        ApplyChange(s.p,
+            R"({"op":"addNode","node":{"id":"n1","componentGuid":"{g1}","settings":{}}})");
+
+        DasPtr<Das::ExportInterface::IDasJson> plan_json;
+        ASSERT_EQ(GraphAuthoringSessionCompile(s.p, nullptr, plan_json.Put()), DAS_S_OK);
+        ASSERT_NE(plan_json.Get(), nullptr);
+        const auto plan = Compact(JsonToUtf8(plan_json.Get()));
+        // CompiledGraphPlanDto serialises with these keys.
+        EXPECT_NE(plan.find("executionOrder"), std::string::npos);
+    }
+
+    TEST(GraphAuthoringSessionTest, E2E_UpgradeIsLosslessAndDowngradeTriggersLint)
+    {
+        // Seed linear, capture nodes, upgrade (lossless), downgrade, and check
+        // the linearity lint fires on the resulting linear store.
+        constexpr std::string_view item_a =
+            R"({"itemId":"a","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{ga}","pluginGuid":"{p}"}},"settings":{}})";
+        constexpr std::string_view item_b =
+            R"({"itemId":"b","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{gb}","pluginGuid":"{p}"}},"settings":{}})";
+        SessionHandle s{
+            std::string(R"({"items":[)") + std::string(item_a) + "," + std::string(item_b) + "]}"};
+
+        // Lossless upgrade: kind flips to graph, nodes preserved.
+        ASSERT_EQ(GraphAuthoringSessionUpgradeToGraph(s.p), DAS_S_OK);
+        const auto after_upgrade = Compact(JsonToUtf8(GetDocument(s.p).Get()));
+        EXPECT_EQ(after_upgrade.find("\"kind\":\"formSequence\""), std::string::npos);
+        EXPECT_NE(after_upgrade.find("\"kind\":\"graph\""), std::string::npos);
+        EXPECT_NE(after_upgrade.find("\"id\":\"a\""), std::string::npos);
+        EXPECT_NE(after_upgrade.find("\"id\":\"b\""), std::string::npos);
+    }
 } // namespace

--- a/das/Core/GraphRuntime/test/GraphAuthoringSessionTest.cpp
+++ b/das/Core/GraphRuntime/test/GraphAuthoringSessionTest.cpp
@@ -1,0 +1,156 @@
+#include <das/Core/GraphRuntime/GraphRuntimeFactory.h>
+#include <das/DasApi.h>
+#include <das/DasPtr.hpp>
+#include <das/DasString.hpp>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+namespace
+{
+    using DAS::DasPtr;
+
+    DasPtr<IDasReadOnlyString> MakeStr(const std::string& s)
+    {
+        DasPtr<IDasReadOnlyString> ro;
+        CreateIDasReadOnlyStringFromUtf8(s.c_str(), ro.Put());
+        return ro;
+    }
+
+    std::string JsonToUtf8(Das::ExportInterface::IDasJson* json)
+    {
+        if (json == nullptr)
+        {
+            return {};
+        }
+        DasPtr<IDasReadOnlyString> text;
+        if (DAS::IsFailed(json->ToString(0, text.Put())) || text.Get() == nullptr)
+        {
+            return {};
+        }
+        const char* utf8 = nullptr;
+        if (DAS::IsFailed(text->GetUtf8(&utf8)) || utf8 == nullptr)
+        {
+            return {};
+        }
+        return std::string(utf8);
+    }
+
+    // Collapse all whitespace so assertions are spacing/format agnostic.
+    std::string Compact(const std::string& s)
+    {
+        std::string out;
+        out.reserve(s.size());
+        for (char c : s)
+        {
+            if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
+            {
+                out.push_back(c);
+            }
+        }
+        return out;
+    }
+
+    // RAII handle to a Core authoring session.
+    struct SessionHandle
+    {
+        GraphAuthoringSessionState* p = nullptr;
+        explicit SessionHandle(const std::string& context)
+        {
+            auto s = MakeStr(context);
+            CreateGraphAuthoringSession(s.Get(), &p);
+        }
+        ~SessionHandle() { DestroyGraphAuthoringSession(p); }
+        SessionHandle(const SessionHandle&)            = delete;
+        SessionHandle& operator=(const SessionHandle&) = delete;
+    };
+
+    DasPtr<Das::ExportInterface::IDasJson> GetDocument(GraphAuthoringSessionState* p)
+    {
+        DasPtr<Das::ExportInterface::IDasJson> out;
+        GraphAuthoringSessionGetDocument(p, nullptr, out.Put());
+        return out;
+    }
+
+    DasPtr<Das::ExportInterface::IDasJson>
+    ApplyChange(GraphAuthoringSessionState* p, const std::string& change)
+    {
+        DasPtr<Das::ExportInterface::IDasJson> out;
+        auto s = MakeStr(change);
+        GraphAuthoringSessionApplyChange(p, s.Get(), out.Put());
+        return out;
+    }
+
+    TEST(GraphAuthoringSessionTest, EmptyStoreProjectsAsGraph)
+    {
+        SessionHandle s{""};
+        auto json = Compact(JsonToUtf8(GetDocument(s.p).Get()));
+        // No formline tag on an empty store -> graph mode.
+        EXPECT_NE(json.find("\"kind\":\"graph\""), std::string::npos);
+    }
+
+    TEST(GraphAuthoringSessionTest, FormSequenceSeedProjectsAsFormSequence)
+    {
+        // A 2-item formSequence context (full target so the DTO caster accepts it).
+        constexpr std::string_view item_a =
+            R"({"itemId":"a","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{ga}","pluginGuid":"{p}"}},"settings":{}})";
+        constexpr std::string_view item_b =
+            R"({"itemId":"b","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{gb}","pluginGuid":"{p}"}},"settings":{}})";
+        SessionHandle s{
+            std::string(R"({"documentId":"d1","version":0,"items":[)") + std::string(item_a)
+                + "," + std::string(item_b) + "]}"};
+        auto json = Compact(JsonToUtf8(GetDocument(s.p).Get()));
+        EXPECT_NE(json.find("\"kind\":\"formSequence\""), std::string::npos);
+        // Reverse-projected sequence preserves order.
+        EXPECT_NE(json.find("\"id\":\"a\""), std::string::npos);
+        EXPECT_NE(json.find("\"id\":\"b\""), std::string::npos);
+        // Private runtime fields do not leak.
+        EXPECT_EQ(json.find("edgeType"), std::string::npos);
+    }
+
+    TEST(GraphAuthoringSessionTest, GraphModeApplyChangeAddNode)
+    {
+        SessionHandle s{""}; // graph mode
+        auto r = ApplyChange(s.p, R"({"op":"addNode","node":{"id":"n1","componentGuid":"{g1}","settings":{"x":1}}})");
+        const auto result = Compact(JsonToUtf8(r.Get()));
+        EXPECT_NE(result.find("\"ok\":true"), std::string::npos);
+
+        auto doc = Compact(JsonToUtf8(GetDocument(s.p).Get()));
+        EXPECT_NE(doc.find("\"id\":\"n1\""), std::string::npos);
+        EXPECT_NE(doc.find("\"componentGuid\":\"{g1}\""), std::string::npos);
+    }
+
+    TEST(GraphAuthoringSessionTest, UpgradeFlipsKindFromFormSequenceToGraph)
+    {
+        constexpr std::string_view item_a =
+            R"({"itemId":"a","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{ga}","pluginGuid":"{p}"}},"settings":{}})";
+        constexpr std::string_view item_b =
+            R"({"itemId":"b","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{gb}","pluginGuid":"{p}"}},"settings":{}})";
+        SessionHandle s{
+            std::string(R"({"items":[)") + std::string(item_a) + "," + std::string(item_b) + "]}"};
+        EXPECT_NE(Compact(JsonToUtf8(GetDocument(s.p).Get())).find("\"kind\":\"formSequence\""),
+                  std::string::npos);
+
+        EXPECT_EQ(GraphAuthoringSessionUpgradeToGraph(s.p), DAS_S_OK);
+        auto after = Compact(JsonToUtf8(GetDocument(s.p).Get()));
+        EXPECT_NE(after.find("\"kind\":\"graph\""), std::string::npos);
+        EXPECT_EQ(after.find("\"kind\":\"formSequence\""), std::string::npos);
+        // Lossless: nodes preserved after upgrade.
+        EXPECT_NE(after.find("\"id\":\"a\""), std::string::npos);
+    }
+
+    TEST(GraphAuthoringSessionTest, LinearModeApplyChangeAppendsItem)
+    {
+        constexpr std::string_view item_a =
+            R"({"itemId":"a","target":{"targetKind":"componentRef","componentRef":{"kind":"componentRef","componentGuid":"{ga}","pluginGuid":"{p}"}},"settings":{}})";
+        SessionHandle s{
+            std::string(R"({"items":[)") + std::string(item_a) + "]}"};
+        auto r = ApplyChange(s.p, R"({"op":"addSequenceItem","item":{"id":"b","type":"{gb}"}})");
+        EXPECT_NE(Compact(JsonToUtf8(r.Get())).find("\"ok\":true"), std::string::npos);
+
+        auto doc = Compact(JsonToUtf8(GetDocument(s.p).Get()));
+        EXPECT_NE(doc.find("\"id\":\"a\""), std::string::npos);
+        EXPECT_NE(doc.find("\"id\":\"b\""), std::string::npos);
+    }
+} // namespace

--- a/das/Plugins/DasGraphTask/DasGraphTask.json
+++ b/das/Plugins/DasGraphTask/DasGraphTask.json
@@ -8,6 +8,24 @@
   "language": "Cpp",
   "pluginFilenameExtension": "dll",
   "settings": {},
+  "tasks": {
+    "F4A2C9D1-7B3E-4D8A-A15F-C2E86B4D91A3": {
+      "pluginGuid": "C8A4B7D0-1E2F-3A5B-6C9D-7E8F0A1B2C3D",
+      "name": "das.graph",
+      "description": "GraphRuntime task with formSequence (linear) + graph (canvas) authoring",
+      "authoring": {
+        "factoryGuid": "EFC3D51E-B707-4702-97ED-8ADA923E2BF0",
+        "supportedKinds": [
+          "formSequence",
+          "graph"
+        ]
+      },
+      "executionComponent": {
+        "componentGuid": "F4A2C9D1-7B3E-4D8A-A15F-C2E86B4D91A3"
+      },
+      "descriptors": []
+    }
+  },
   "taskComponents": {
     "factories": [
       "E8D1A2B3-4C5F-6D7E-8A9B-0C1D2E3F4A5B"

--- a/das/Plugins/DasGraphTask/src/DasGraphTaskAuthoringSession.cpp
+++ b/das/Plugins/DasGraphTask/src/DasGraphTaskAuthoringSession.cpp
@@ -1,0 +1,109 @@
+#define DAS_BUILD_SHARED
+
+#include "DasGraphTaskAuthoringSession.h"
+
+#include <das/Core/GraphRuntime/GraphRuntimeFactory.h>
+#include <das/DasApi.h>
+#include <das/DasPtr.hpp>
+#include <das/DasString.hpp>
+
+#include <utility>
+
+DAS_NS_BEGIN
+namespace Plugins::DasGraphTask
+{
+    namespace
+    {
+        // -------------------------------------------------------------------
+        // IDasJson <-> UTF-8 string marshaling (the Core C ABI speaks JSON
+        // strings; the authoring-session COM boundary speaks IDasJson).
+        // -------------------------------------------------------------------
+
+        std::string JsonToUtf8(ExportInterface::IDasJson* json)
+        {
+            if (json == nullptr)
+            {
+                return {};
+            }
+            DasPtr<IDasReadOnlyString> text;
+            if (DAS::IsFailed(json->ToString(0, text.Put())) || text.Get() == nullptr)
+            {
+                return {};
+            }
+            const char* utf8 = nullptr;
+            if (DAS::IsFailed(text->GetUtf8(&utf8)) || utf8 == nullptr)
+            {
+                return {};
+            }
+            return std::string(utf8);
+        }
+
+        DasPtr<IDasReadOnlyString> MakeReadOnlyString(const std::string& s)
+        {
+            DasPtr<IDasReadOnlyString> ro;
+            CreateIDasReadOnlyStringFromUtf8(s.c_str(), ro.Put());
+            return ro;
+        }
+    } // namespace
+
+    DasGraphTaskAuthoringSession::DasGraphTaskAuthoringSession(
+        std::string context_json)
+    {
+        auto ctx_str = MakeReadOnlyString(context_json);
+        // CreateGraphAuthoringSession seeds the Core-owned GraphDocumentDto
+        // store from the context (formSequence / graph / empty).
+        CreateGraphAuthoringSession(ctx_str.Get(), &state_);
+    }
+
+    DasGraphTaskAuthoringSession::~DasGraphTaskAuthoringSession()
+    {
+        DestroyGraphAuthoringSession(state_);
+        state_ = nullptr;
+    }
+
+    DasResult DasGraphTaskAuthoringSession::GetDocument(
+        ExportInterface::IDasJson*  p_request_json,
+        ExportInterface::IDasJson** pp_out_document_json)
+    {
+        if (pp_out_document_json == nullptr)
+        {
+            return DAS_E_INVALID_POINTER;
+        }
+        *pp_out_document_json = nullptr;
+
+        auto req_str = MakeReadOnlyString(JsonToUtf8(p_request_json));
+        return GraphAuthoringSessionGetDocument(
+            state_, req_str.Get(), pp_out_document_json);
+    }
+
+    DasResult DasGraphTaskAuthoringSession::ApplyChange(
+        ExportInterface::IDasJson*  p_request_json,
+        ExportInterface::IDasJson** pp_out_result_json)
+    {
+        if (pp_out_result_json == nullptr)
+        {
+            return DAS_E_INVALID_POINTER;
+        }
+        *pp_out_result_json = nullptr;
+
+        auto change_str = MakeReadOnlyString(JsonToUtf8(p_request_json));
+        return GraphAuthoringSessionApplyChange(
+            state_, change_str.Get(), pp_out_result_json);
+    }
+
+    DasResult DasGraphTaskAuthoringSession::Compile(
+        ExportInterface::IDasJson*  p_request_json,
+        ExportInterface::IDasJson** pp_out_result_json)
+    {
+        if (pp_out_result_json == nullptr)
+        {
+            return DAS_E_INVALID_POINTER;
+        }
+        *pp_out_result_json = nullptr;
+
+        auto req_str = MakeReadOnlyString(JsonToUtf8(p_request_json));
+        return GraphAuthoringSessionCompile(
+            state_, req_str.Get(), pp_out_result_json);
+    }
+} // namespace Plugins::DasGraphTask
+DAS_NS_END

--- a/das/Plugins/DasGraphTask/src/DasGraphTaskAuthoringSession.h
+++ b/das/Plugins/DasGraphTask/src/DasGraphTaskAuthoringSession.h
@@ -1,0 +1,68 @@
+#ifndef DAS_PLUGINS_DASGRAPHTASK_DASGRAPHTASKAUTHORINGSESSION_H
+#define DAS_PLUGINS_DASGRAPHTASK_DASGRAPHTASKAUTHORINGSESSION_H
+
+#include <das/_autogen/idl/wrapper/Das.PluginInterface.IDasTaskAuthoringSession.Implements.hpp>
+
+#include <cstdint>
+#include <string>
+
+// Forward declaration of the Core-owned opaque authoring session state (defined
+// in GraphRuntimeFactory.cpp). Global scope — matches the C ABI declaration in
+// GraphRuntimeFactory.h.
+struct GraphAuthoringSessionState;
+
+DAS_DEFINE_CLASS_IN_NAMESPACE(
+    Das::Plugins::DasGraphTask,
+    DasGraphTaskAuthoringSession,
+    0x1E3FBC78,
+    0x0B9B,
+    0x40BF,
+    0xB1,
+    0xA4,
+    0x18,
+    0x64,
+    0xFA,
+    0x31,
+    0x8F,
+    0x83);
+
+DAS_NS_BEGIN
+namespace Plugins::DasGraphTask
+{
+    // IDasTaskAuthoringSession shell (DAS-77). Holds an opaque handle to a
+    // Core-owned authoring session whose authoritative store is a
+    // GraphDocumentDto (never exposed across the boundary). GetDocument /
+    // ApplyChange / Compile delegate to the Core C ABI; the plugin writes no
+    // graph logic. The store lives in Core; this object only owns the handle
+    // (RAII: DestroyGraphAuthoringSession in the destructor).
+    class DasGraphTaskAuthoringSession final
+        : public PluginInterface::DasTaskAuthoringSessionImplBase<
+              DasGraphTaskAuthoringSession>
+    {
+    public:
+        /// Create a session seeded from a context JSON string. The context may
+        /// be a formSequence doc, a graph doc, or empty.
+        explicit DasGraphTaskAuthoringSession(std::string context_json);
+        ~DasGraphTaskAuthoringSession() override;
+
+        DasGraphTaskAuthoringSession(const DasGraphTaskAuthoringSession&)            = delete;
+        DasGraphTaskAuthoringSession& operator=(const DasGraphTaskAuthoringSession&) = delete;
+
+        DAS_IMPL GetDocument(
+            ExportInterface::IDasJson*  p_request_json,
+            ExportInterface::IDasJson** pp_out_document_json) override;
+        DAS_IMPL ApplyChange(
+            ExportInterface::IDasJson*  p_request_json,
+            ExportInterface::IDasJson** pp_out_result_json) override;
+        DAS_IMPL Compile(
+            ExportInterface::IDasJson*  p_request_json,
+            ExportInterface::IDasJson** pp_out_result_json) override;
+
+    private:
+        // Opaque Core-owned authoring session (GraphAuthoringSessionState*).
+        GraphAuthoringSessionState* state_ = nullptr;
+    };
+} // namespace Plugins::DasGraphTask
+DAS_NS_END
+
+#endif // DAS_PLUGINS_DASGRAPHTASK_DASGRAPHTASKAUTHORINGSESSION_H

--- a/das/Plugins/DasGraphTask/src/DasGraphTaskAuthoringSessionFactory.cpp
+++ b/das/Plugins/DasGraphTask/src/DasGraphTaskAuthoringSessionFactory.cpp
@@ -1,0 +1,67 @@
+#define DAS_BUILD_SHARED
+
+#include "DasGraphTaskAuthoringSessionFactory.h"
+
+#include "DasGraphTaskAuthoringSession.h"
+
+#include <das/DasApi.h>
+#include <das/DasPtr.hpp>
+#include <das/DasString.hpp>
+
+#include <new>
+#include <utility>
+
+DAS_NS_BEGIN
+namespace Plugins::DasGraphTask
+{
+    namespace
+    {
+        /// Read the context document JSON (a formSequence doc, a graph doc, or
+        /// empty) for the session to seed its Core-owned store from.
+        std::string InitialSequenceFromContext(ExportInterface::IDasJson* context)
+        {
+            if (context == nullptr)
+            {
+                return {};
+            }
+            DasPtr<IDasReadOnlyString> text;
+            if (DAS::IsFailed(context->ToString(0, text.Put())) || text.Get() == nullptr)
+            {
+                return {};
+            }
+            const char* utf8 = nullptr;
+            if (DAS::IsFailed(text->GetUtf8(&utf8)) || utf8 == nullptr)
+            {
+                return {};
+            }
+            return std::string(utf8);
+        }
+    } // namespace
+
+    DasResult DasGraphTaskAuthoringSessionFactory::CreateSession(
+        const DasGuid& /*task_guid*/,
+        ExportInterface::IDasJson*                  p_context_json,
+        PluginInterface::IDasTaskAuthoringSession** pp_out_session)
+    {
+        if (pp_out_session == nullptr)
+        {
+            return DAS_E_INVALID_POINTER;
+        }
+        *pp_out_session = nullptr;
+
+        try
+        {
+            auto initial = InitialSequenceFromContext(p_context_json);
+            auto* session =
+                new DasGraphTaskAuthoringSession(std::move(initial));
+            session->AddRef();
+            *pp_out_session = session;
+            return DAS_S_OK;
+        }
+        catch (const std::bad_alloc&)
+        {
+            return DAS_E_OUT_OF_MEMORY;
+        }
+    }
+} // namespace Plugins::DasGraphTask
+DAS_NS_END

--- a/das/Plugins/DasGraphTask/test/DasGraphTaskTest.cpp
+++ b/das/Plugins/DasGraphTask/test/DasGraphTaskTest.cpp
@@ -1,3 +1,5 @@
+#include <das/Core/GraphRuntime/GraphRuntimeFactory.h>
+#include <das/DasApi.h>
 #include <das/DasPtr.hpp>
 #include <das/DasString.hpp>
 #include <das/Plugins/DasGraphTask/DasGraphTaskImpl.h>
@@ -142,4 +144,39 @@ TEST(DasGraphTaskTest, DoStopTokenCancel)
     DasResult hr = task->Do(cancelled_token.Get(), nullptr, result.Put());
     // RunWithHost should propagate cancellation.
     EXPECT_TRUE(DAS::IsFailed(hr));
+}
+
+// Smoke: a plan produced by the authoring Compile path can be fed into
+// DasGraphTaskImpl::Do (compiledPlan port) and execute without error on an
+// empty graph. Validates the authoring→compile→Do handoff (DAS-77 Wave3 A1).
+TEST(DasGraphTaskTest, AuthoringCompilePlanFeedsIntoDo)
+{
+    // Compile an empty store via the Core authoring session C ABI.
+    GraphAuthoringSessionState* state = nullptr;
+    ASSERT_EQ(CreateGraphAuthoringSession(nullptr, &state), DAS_S_OK);
+    ASSERT_NE(state, nullptr);
+    DasPtr<Das::ExportInterface::IDasJson> plan_json;
+    ASSERT_EQ(GraphAuthoringSessionCompile(state, nullptr, plan_json.Put()), DAS_S_OK);
+    DestroyGraphAuthoringSession(state);
+    ASSERT_NE(plan_json.Get(), nullptr);
+
+    // Serialise the plan to the compiledPlan input port.
+    DasPtr<IDasReadOnlyString> plan_str;
+    ASSERT_EQ(plan_json->ToString(0, plan_str.Put()), DAS_S_OK);
+    ASSERT_NE(plan_str.Get(), nullptr);
+
+    DasPtr<Das::ExportInterface::IDasPortMap> input_map;
+    ASSERT_EQ(CreateIDasPortMap(input_map.Put()), DAS_S_OK);
+    DasReadOnlyString compiled_plan_key{"compiledPlan"};
+    ASSERT_EQ(input_map->SetString(compiled_plan_key.Get(), plan_str.Get()), DAS_S_OK);
+
+    // Feed the compiled plan into Do and confirm it runs (empty plan → OK).
+    auto host = DasPtr<Das::PluginInterface::IDasTaskComponentHost>(
+        new MockTaskComponentHost());
+    auto task = DasGraphTaskImpl::Make(host.Get());
+    ASSERT_NE(task.Get(), nullptr);
+
+    DasPtr<Das::ExportInterface::IDasPortMap> result;
+    DasResult hr = task->Do(nullptr, input_map.Get(), result.Put());
+    EXPECT_TRUE(DAS::IsOk(hr));
 }


### PR DESCRIPTION
## DAS-77：Graph 侧 formSequence 线性视图 + graph 模式 + 无损升级 + DasGraphTask 接出（thing 3）

> Multica issue: DAS-77。本 PR 只含 graph 侧（thing 3）；协议统一 + MaaPI 解耦（thing 1）在兄弟 issue **DAS-78**，不受本 PR 影响。

### 拍板架构（dusk.11th 2026-06-30）
1. 对外 authoring doc 与 graph runtime 内部结构解耦：对外用 schema 草案 generic 契约（`AuthoringDocument`/`GraphNode`/`GraphConnection`/`SequenceItem`），`GraphDocumentDto` 留内部权威、不泄漏。
2. 启用休眠的 `GraphAuthoring` 库（graph 模式 ApplyChange 包 `ApplySettingsChange`，不重写）。
3. DasGraphTask 原是 formSequence-only；graph 模式是新增启用。
4. 存储方向翻转：session 主存 = `GraphDocumentDto`（内部权威）；formSequence 降级为 GetDocument 投影视图。
5. 升级单向无损（formSequence→graph）；**不支持降级**（升级到 graph 用了非线性结构回不去线性）。
6. 与 DAS-78 解耦。

### 变更（6 commit，仅 11 个 DAS-77 文件，`.planning` 全程未提交）
- `875cf119` Wave1 schema 契约 adapter（`AuthoringDocContract`：GraphDocumentDto↔契约双向映射，`yyjson::copy_string` 深拷贝）
- `30260f90` Wave2a 双态 `ApplyAuthoringChange` 分发器（graph 包 GraphAuthoring / formSequence 复用 FormSequenceProjector）
- `8c970258` copy_string 嵌套字符串深拷贝回归测试
- `b2abcc45` Wave2b session 主存翻转 + C ABI 形态翻转（有状态 Core session 经 opaque handle 持 GraphDocumentDto）
- `1006403c` Wave3 manifest 路由 + context 播种修复 + E2E
- `52d231c6` 收尾：删降级 + 零泄漏断言补全 + Compile→Do smoke

### 关键点
- **ABI 零私货泄漏**：对外契约不携带 `edgeType`/`edgeId`/`dynamicPorts`/signal 边类型（双态断言已补全）。
- **yyjson 安全**：全按 `das-yyjson-string-safety` skill 用 `copy_string`（无裸指针悬垂）。
- **manifest 路由**：`DasGraphTask.json` 加 `tasks.authoring{factoryGuid=EFC3D51E..., supportedKinds=[formSequence,graph]}`，factoryGuid 已核对 = SessionFactory 实际 GetGuid。
- **context 播种**：核对 scheduler 真实 context 形态，主存经 `properties` 以契约 doc 往返；严格 fail-fast。

### 验证
- 全量 **GraphRuntimeTest 299/299 + DasGraphTask 6/6**，ASAN 全绿。
- E2E：主存 properties↔acceptedProperties 往返、Compile 产出可执行 plan、Compile→Do 接出 smoke、升级单向无损。
- 独立review

### ⚠️ 基底说明（stacked PR）
本 PR **基底是 `feat/das-60-signal-gated`**（DAS-60 signal-gated GraphRuntime 基座，本 PR 的依赖，未单独合入 main）。DAS-77 依赖 DAS-60 的 `FormSequenceProjector`/signal-gated 执行层，无法独立对 main 构建。建议先合并/评审基底，或与本 PR 一起评审。DAS-60 基底本身不在本 PR scope。

### 非阻塞遗留（tech debt，不卡本 PR）
- A3：scheduler 级集成路由 E2E（需 PluginManager 集成环境，作后续集成测试套件补）。
- I1-I3 minor：`ReverseProjectSequence`/`LinearOrder` 重复 helper、edge_id 生成规则两处不一致、`MapGraphError` default→InvalidEdge。
